### PR TITLE
Fix needs_more_settling not settling more

### DIFF
--- a/src/bin/edit/main.rs
+++ b/src/bin/edit/main.rs
@@ -289,8 +289,6 @@ fn print_version() {
 }
 
 fn draw(ctx: &mut Context, state: &mut State) {
-    let root_focused = ctx.contains_focus();
-
     draw_menubar(ctx, state);
     draw_editor(ctx, state);
     draw_statusbar(ctx, state);
@@ -323,33 +321,38 @@ fn draw(ctx: &mut Context, state: &mut State) {
         draw_error_log(ctx, state);
     }
 
-    if root_focused {
+    if let Some(key) = ctx.keyboard_input() {
         // Shortcuts that are not handled as part of the textarea, etc.
-        if ctx.consume_shortcut(kbmod::CTRL | vk::N) {
+
+        if key == kbmod::CTRL | vk::N {
             draw_add_untitled_document(ctx, state);
-        } else if ctx.consume_shortcut(kbmod::CTRL | vk::O) {
+        } else if key == kbmod::CTRL | vk::O {
             state.wants_file_picker = StateFilePicker::Open;
-        } else if ctx.consume_shortcut(kbmod::CTRL | vk::S) {
+        } else if key == kbmod::CTRL | vk::S {
             state.wants_save = true;
-        } else if ctx.consume_shortcut(kbmod::CTRL_SHIFT | vk::S) {
+        } else if key == kbmod::CTRL_SHIFT | vk::S {
             state.wants_file_picker = StateFilePicker::SaveAs;
-        } else if ctx.consume_shortcut(kbmod::CTRL | vk::W) {
+        } else if key == kbmod::CTRL | vk::W {
             state.wants_close = true;
-        } else if ctx.consume_shortcut(kbmod::CTRL | vk::P) {
+        } else if key == kbmod::CTRL | vk::P {
             state.wants_document_picker = true;
-        } else if ctx.consume_shortcut(kbmod::CTRL | vk::Q) {
+        } else if key == kbmod::CTRL | vk::Q {
             state.wants_exit = true;
-        } else if state.wants_search.kind != StateSearchKind::Disabled
-            && ctx.consume_shortcut(kbmod::CTRL | vk::F)
+        } else if key == kbmod::CTRL | vk::F && state.wants_search.kind != StateSearchKind::Disabled
         {
             state.wants_search.kind = StateSearchKind::Search;
             state.wants_search.focus = true;
-        } else if state.wants_search.kind != StateSearchKind::Disabled
-            && ctx.consume_shortcut(kbmod::CTRL | vk::R)
+        } else if key == kbmod::CTRL | vk::R && state.wants_search.kind != StateSearchKind::Disabled
         {
             state.wants_search.kind = StateSearchKind::Replace;
             state.wants_search.focus = true;
+        } else {
+            return;
         }
+
+        // All of the above shortcuts happen to require a rerender.
+        ctx.needs_rerender();
+        ctx.set_input_consumed();
     }
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -695,11 +695,13 @@ impl Tui {
             needs_settling |= self.move_focus(input);
         }
 
+        // `needs_more_settling()` depends on the current value
+        // of `settling_have` and so we increment it first.
+        self.settling_have += 1;
+
         if needs_settling {
             self.needs_more_settling();
         }
-
-        self.settling_have += 1;
 
         // Remove cached text editors that are no longer in use.
         self.cached_text_buffers.retain(|c| c.seen);
@@ -1649,8 +1651,20 @@ impl<'a> Context<'a, '_> {
         }
     }
 
-    fn set_input_consumed(&mut self) {
+    /// Returns current keyboard input, if any.
+    /// Returns None if the input was already consumed.
+    pub fn keyboard_input(&self) -> Option<InputKey> {
+        if self.input_consumed { None } else { self.input_keyboard }
+    }
+
+    #[inline]
+    pub fn set_input_consumed(&mut self) {
         debug_assert!(!self.input_consumed);
+        self.set_input_consumed_unchecked();
+    }
+
+    #[inline]
+    fn set_input_consumed_unchecked(&mut self) {
         self.input_consumed = true;
     }
 


### PR DESCRIPTION
Since the focus can change during a frame, calling `ctx.contains_focus()`
to get the root focus early is incorrect. That's separately fixed by #12.
More importantly, the `needs_rerender` call was missing for these shortcuts.