### PR TITLE
Cargo.toml: add MSRV of 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "edit"
 version = "1.0.0"
 edition = "2024"
+rust-version = "1.87"
 
 [[bench]]
 name = "lib"


### PR DESCRIPTION
`edit` requires at least Rust 1.87, to support the unstable `MaybeUninit::write_filled` method. Update `Cargo.toml` to document this, so that there's a clear error message when attempting to build with an older toolchain.

(I think eliminating the use of this method (and the `maybe_uninit_fill` unstable feeature) would allow the MSRV to be reduced to 1.86.)