### PR TITLE
Fix duplicate keyboard shortcut for Redo and Replace

### DIFF
--- a/src/bin/edit/draw_menubar.rs
+++ b/src/bin/edit/draw_menubar.rs
@@ -81,7 +81,7 @@ fn draw_menu_edit(ctx: &mut Context, state: &mut State) {
             state.wants_search.kind = StateSearchKind::Search;
             state.wants_search.focus = true;
         }
-        if ctx.menubar_menu_button(loc(LocId::EditReplace), 'R', kbmod::CTRL | vk::R) {
+        if ctx.menubar_menu_button(loc(LocId::EditReplace), 'H', kbmod::CTRL | vk::H) {
             state.wants_search.kind = StateSearchKind::Replace;
             state.wants_search.focus = true;
         }


### PR DESCRIPTION
Fixes #56 

I chose ctrl+h because on Windows that's the standard in things like notepad, so a lot of people already have it in their muscle memory 💪