### PR TITLE
remove mention of RUSTC_BOOTSTRAP=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,5 @@ This editor pays homage to the classic [MS-DOS Editor](https://en.wikipedia.org/
 
 * [Install Rust](https://www.rust-lang.org/tools/install)
 * Install the nightly toolchain: `rustup install nightly`
-  * Alternatively, set the environment variable `RUSTC_BOOTSTRAP=1`
 * Clone the repository
 * For a release build, run: `cargo build --config .cargo/release.toml --release`


### PR DESCRIPTION
RUSTC_BOOTSTRAP mainly exists for the compiler to bootstrap itself, allowing a stable compiler to compile the STD.

It is best left off unless you know what you are doing, so having a mention of it in a readme of a "random" project is probably not a great idea, especially without a warning/explanation to go with it.

As far as I know, using RUSTC_BOOTSTRAP=1 is also not really supported outside of building the compiler and the STD. Thus making it even less ideal to mention using it in the build instructions of a project that isn't related to this.