### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
### Summary

- This PR adds `rust-toolchain.toml`, so the Nightly toolchain no longer needs to be installed manually.