### PR TITLE
Don't apply MSVC compile flags for non-MSVC toolchains

### DIFF
--- a/.cargo/release.toml
+++ b/.cargo/release.toml
@@ -7,7 +7,7 @@
 # Avoid linking with vcruntime140.dll by statically linking everything,
 # and then explicitly linking with ucrtbase.dll dynamically.
 # We do this, because vcruntime140.dll is an optional Windows component.
-[target.'cfg(target_os = "windows")']
+[target.'cfg(all(target_os = "windows", target_env = "msvc"))']
 rustflags = [
     "-Ctarget-feature=+crt-static",
     "-Clink-args=/DEFAULTLIB:ucrt.lib",


### PR DESCRIPTION
MinGW toolchains just don't support these flags