### PR TITLE
Fix language match on Linux (Unix?)

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -526,7 +526,9 @@ pub fn preferred_languages(arena: &Arena) -> Vec<ArenaString<'_>, &Arena> {
     let mut locales = Vec::new_in(arena);
 
     for key in ["LANGUAGE", "LC_ALL", "LANG"] {
-        if let Ok(val) = std::env::var(key) {
+        if let Ok(val) = std::env::var(key)
+            && !val.is_empty()
+        {
             locales.extend(
                 val.split(':').filter(|s| !s.is_empty()).map(|s| ArenaString::from_str(arena, s)),
             );


### PR DESCRIPTION
In Linux, it is possible for the `LANGUAGE` variable to exist but have a empty value,

Before: 

![图片](https://github.com/user-attachments/assets/1c9971b6-f612-421e-a915-96ad9971ed72)

After:

![图片](https://github.com/user-attachments/assets/5ddc708d-27e6-4cbd-9699-bfef84e0fb35)
