### PR TITLE
Fix SVG by moving the processing instruction to the start

### DIFF
--- a/assets/Microsoft_logo_(1980).svg
+++ b/assets/Microsoft_logo_(1980).svg
@@ -1,6 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Source: https://commons.wikimedia.org/wiki/File:Microsoft_logo_(1980).svg -->
 <!-- License: Public domain -->
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" id="svg8" version="1.1" viewBox="0 0 264.58333 52.916669" height="200" width="1000">
   <defs id="defs2"/>
   <metadata id="metadata5">


### PR DESCRIPTION
fix(assets): remove extraneous Source: and License: elements

Per the SVG 2 Conformance Criteria:

  A DOM node tree or subtree rooted at a given element is a conforming SVG
  DOM subtree if it forms a SVG document fragment that adheres to the
  specification described in this document (Scalable Vector Graphics (SVG)
  Specification). Specifically, it:

    - is rooted by an ‘svg’ element in the SVG namespace,

  [...]

With the extra headers, both GitHub's preview function, Firefox and
Gwenview (KDE) fails to render the vector image:

  GitHub:
    Error rendering embedded code

    Invalid image source.

  Firefox:

    XML Parsing Error: XML or text declaration not at start of entity
    Location: https://raw.githubusercontent.com/microsoft/edit/refs/heads/main/assets/Microsoft_logo_(1980).svg
    Line Number 3, Column 1:

    <?xml version="1.0" encoding="UTF-8" standalone="no"?>
    ^

  Gwenview:

    Renders an empty image.

Move the header below the <svg> element to fix the above issues.
