### PR TITLE
Enhance vscode related debug configurations

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,6 +6,7 @@
             "type": "process",
             "command": "cargo",
             "args": [
+                "+nightly",
                 "build",
                 "--package",
                 "edit",


### PR DESCRIPTION
Specify the `toolchain` version when debugging the program thru `vscode`.