### PR TITLE
Update Cargo.toml to remove "future" in comment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ harness = false
 debug-layout = []
 debug-latency = []
 
-# `opt-level = "s"` may be useful in the future as it significantly reduces binary size.
+# We use `opt-level = "s"` as it significantly reduces binary size.
 # We could then use the `#[optimize(speed)]` attribute for spot optimizations.
 # Unfortunately, that attribute currently doesn't work on intrinsics such as memset.
 [profile.release]


### PR DESCRIPTION
opt level = s is clearly used a few lines below this comment.

I updated the comment to just mention this :)