### PR TITLE
Fix the deal-loop issue when executing replace-all with the same replacement as the search criteria

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -1142,8 +1142,10 @@ impl TextBuffer {
 
         if search.next_search_offset != offset {
             search.next_search_offset = offset;
-            search.regex.reset(offset);
         }
+
+        // Make the regexp matching process starts here.
+        search.regex.reset(offset);
 
         let mut hit = search.regex.next();
 


### PR DESCRIPTION
The reproduce steps:

1. Launch the `edit` program.
2. Searching something, e.g., `mod`.
3. Replace them by the content `mod`.
4. Execute `replace all`.

The program stick into the `dead-loop` issue.

![image](https://github.com/user-attachments/assets/b57ccc41-1cbf-423a-9fc3-61e204165832)
