### PR TITLE
Fix access key for Replace in Edit menu

### DIFF
--- a/src/bin/edit/draw_menubar.rs
+++ b/src/bin/edit/draw_menubar.rs
@@ -81,7 +81,7 @@ fn draw_menu_edit(ctx: &mut Context, state: &mut State) {
             state.wants_search.kind = StateSearchKind::Search;
             state.wants_search.focus = true;
         }
-        if ctx.menubar_menu_button(loc(LocId::EditReplace), 'R', kbmod::CTRL | vk::R) {
+        if ctx.menubar_menu_button(loc(LocId::EditReplace), 'L', kbmod::CTRL | vk::R) {
             state.wants_search.kind = StateSearchKind::Replace;
             state.wants_search.focus = true;
         }


### PR DESCRIPTION
Currently, there's a conflict of access keys in the Edit menu – both Redo and Replace are assigned to `R`. This means that the Replace feature can't be accessed by Alt followed by a letter.

With this one-character bugfix, I've changed Replace's access key to `L`, which doesn't conflict with any of the other items in this menu.

This matches the access key used in old-school MS-DOS Edit.

Closes #56