### PR TITLE
remove simd::distance

### DIFF
--- a/src/simd/memchr2.rs
+++ b/src/simd/memchr2.rs
@@ -5,8 +5,6 @@
 
 use std::ptr;
 
-use super::distance;
-
 /// `memchr`, but with two needles.
 ///
 /// Returns the index of the first occurrence of either needle in the
@@ -18,7 +16,7 @@ pub fn memchr2(needle1: u8, needle2: u8, haystack: &[u8], offset: usize) -> usiz
         let end = beg.add(haystack.len());
         let it = beg.add(offset.min(haystack.len()));
         let it = memchr2_raw(needle1, needle2, it, end);
-        distance(it, beg)
+        it.offset_from_unsigned(beg)
     }
 }
 
@@ -80,7 +78,7 @@ unsafe fn memchr2_avx2(needle1: u8, needle2: u8, mut beg: *const u8, end: *const
 
         let n1 = _mm256_set1_epi8(needle1 as i8);
         let n2 = _mm256_set1_epi8(needle2 as i8);
-        let mut remaining = distance(end, beg);
+        let mut remaining = end.offset_from_unsigned(beg);
 
         while remaining >= 32 {
             let v = _mm256_loadu_si256(beg as *const _);
@@ -106,7 +104,7 @@ unsafe fn memchr2_neon(needle1: u8, needle2: u8, mut beg: *const u8, end: *const
     unsafe {
         use std::arch::aarch64::*;
 
-        if distance(end, beg) >= 16 {
+        if end.offset_from_unsigned(beg) >= 16 {
             let n1 = vdupq_n_u8(needle1);
             let n2 = vdupq_n_u8(needle2);
 
@@ -127,7 +125,7 @@ unsafe fn memchr2_neon(needle1: u8, needle2: u8, mut beg: *const u8, end: *const
                 }
 
                 beg = beg.add(16);
-                if distance(end, beg) < 16 {
+                if end.offset_from_unsigned(beg) < 16 {
                     break;
                 }
             }

--- a/src/simd/memset.rs
+++ b/src/simd/memset.rs
@@ -15,8 +15,6 @@
 
 use std::mem;
 
-use super::distance;
-
 /// A marker trait for types that are safe to `memset`.
 ///
 /// # Safety
@@ -100,7 +98,7 @@ unsafe fn memset_sse2(mut beg: *mut u8, end: *mut u8, val: u64) {
         #[cfg(target_arch = "x86_64")]
         use std::arch::x86_64::*;
 
-        let mut remaining = distance(end, beg);
+        let mut remaining = end.offset_from_unsigned(beg);
 
         if remaining >= 16 {
             let fill = _mm_set1_epi64x(val as i64);
@@ -150,7 +148,7 @@ fn memset_avx2(mut beg: *mut u8, end: *mut u8, val: u64) {
         use std::arch::x86_64::*;
         use std::hint::black_box;
 
-        let mut remaining = distance(end, beg);
+        let mut remaining = end.offset_from_unsigned(beg);
 
         if remaining >= 128 {
             let fill = _mm256_set1_epi64x(val as i64);
@@ -212,7 +210,7 @@ fn memset_avx2(mut beg: *mut u8, end: *mut u8, val: u64) {
 unsafe fn memset_neon(mut beg: *mut u8, end: *mut u8, val: u64) {
     unsafe {
         use std::arch::aarch64::*;
-        let mut remaining = distance(end, beg);
+        let mut remaining = end.offset_from_unsigned(beg);
 
         if remaining >= 32 {
             let fill = vdupq_n_u64(val);

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -10,9 +10,3 @@ mod memset;
 pub use memchr2::*;
 pub use memrchr2::*;
 pub use memset::*;
-
-// Can be replaced with `sub_ptr` once it's stabilized.
-#[inline(always)]
-unsafe fn distance<T>(hi: *const T, lo: *const T) -> usize {
-    unsafe { usize::try_from(hi.offset_from(lo)).unwrap_unchecked() }
-}

--- a/src/unicode/utf8.rs
+++ b/src/unicode/utf8.rs
@@ -203,7 +203,7 @@ impl<'a> Utf8Chars<'a> {
         self.offset += 1;
 
         // SAFETY: If `cp` wasn't a valid codepoint, we already returned U+FFFD above.
-        #[allow(clippy::transmute_int_to_char)]
+        #[allow(unnecessary_transmutes)]
         unsafe {
             char::from_u32_unchecked(cp)
         }

--- a/src/unicode/utf8.rs
+++ b/src/unicode/utf8.rs
@@ -203,10 +203,7 @@ impl<'a> Utf8Chars<'a> {
         self.offset += 1;
 
         // SAFETY: If `cp` wasn't a valid codepoint, we already returned U+FFFD above.
-        #[allow(unnecessary_transmutes)]
-        unsafe {
-            char::from_u32_unchecked(cp)
-        }
+        unsafe { char::from_u32_unchecked(cp) }
     }
 
     // This simultaneously serves as a `cold_path` marker.


### PR DESCRIPTION
Since [`offset_from_unsigned` has been stabilized](https://doc.rust-lang.org/stable/std/primitive.pointer.html#method.offset_from_unsigned), we can remove simd::distance now.