### PR TITLE
Solve Panic when pressing Shift + Tab in an empty line

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -1990,6 +1990,10 @@ impl TextBuffer {
         let mut y = beg.logical_pos.y;
 
         loop {
+            if offset >= replacement.len() {
+                break;
+            }
+
             let mut remove = 0;
 
             if replacement[offset] == b'\t' {

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -2019,9 +2019,6 @@ impl TextBuffer {
             }
 
             (offset, y) = unicode::newlines_forward(&replacement, offset, y, y + 1);
-            if offset >= replacement.len() {
-                break;
-            }
         }
 
         if replacement.len() == initial_len {


### PR DESCRIPTION
This fixes issue #112 , where pressing Shift+Tab at the beginning of an empty line would cause the program to panic.

We now check at the very beginning of the loop whether the offset is greater than or equal to the replacement length, instead of doing it after attempting the action.

Closes #112