### PR TITLE
fix: missing fallback for memchr2

### DIFF
--- a/src/simd/memchr2.rs
+++ b/src/simd/memchr2.rs
@@ -26,6 +26,9 @@ unsafe fn memchr2_raw(needle1: u8, needle2: u8, beg: *const u8, end: *const u8) 
 
     #[cfg(target_arch = "aarch64")]
     return unsafe { memchr2_neon(needle1, needle2, beg, end) };
+
+    #[allow(unreachable_code)]
+    return unsafe { memchr2_fallback(needle1, needle2, beg, end) };
 }
 
 unsafe fn memchr2_fallback(


### PR DESCRIPTION
a call to `memchr2_fallback` is missing in `memchr2_raw`, make it uncompilable under arch other than x86-64 and aarch64.