### PR TITLE
Add support for non-x86/AArch64 architectures

### DIFF
--- a/src/simd/memchr2.rs
+++ b/src/simd/memchr2.rs
@@ -26,6 +26,9 @@ unsafe fn memchr2_raw(needle1: u8, needle2: u8, beg: *const u8, end: *const u8) 
 
     #[cfg(target_arch = "aarch64")]
     return unsafe { memchr2_neon(needle1, needle2, beg, end) };
+
+    #[allow(unreachable_code)]
+    return unsafe { memchr2_fallback(needle1, needle2, beg, end) };
 }
 
 unsafe fn memchr2_fallback(

--- a/src/simd/memset.rs
+++ b/src/simd/memset.rs
@@ -77,6 +77,37 @@ fn memset_raw(beg: *mut u8, end: *mut u8, val: u64) {
 
     #[cfg(target_arch = "aarch64")]
     return unsafe { memset_neon(beg, end, val) };
+
+    #[allow(unreachable_code)]
+    return unsafe { memset_fallback(beg, end, val) };
+}
+
+#[inline(never)]
+unsafe fn memset_fallback(mut beg: *mut u8, end: *mut u8, val: u64) {
+    unsafe {
+        let mut remaining = end.offset_from_unsigned(beg);
+
+        while remaining >= 8 {
+            (beg as *mut u64).write_unaligned(val);
+            (end.sub(8) as *mut u64).write_unaligned(val);
+
+            beg = beg.add(8);
+            remaining -= 8;
+        }
+
+        if remaining >= 4 {
+            // 4-7 bytes remaining
+            (beg as *mut u32).write_unaligned(val as u32);
+            (end.sub(4) as *mut u32).write_unaligned(val as u32);
+        } else if remaining >= 2 {
+            // 2-3 bytes remaining
+            (beg as *mut u16).write_unaligned(val as u16);
+            (end.sub(2) as *mut u16).write_unaligned(val as u16);
+        } else if remaining >= 1 {
+            // 1 byte remaining
+            beg.write(val as u8);
+        }
+    }
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]


### PR DESCRIPTION
The new memset fallback code is based on the existing SSE2 variant.