### PR TITLE
ai generated suggestions in the tui

### DIFF
--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -51,16 +51,17 @@ pub enum IndexedColor {
 
     Background,
     Foreground,
+    MutedForeground,
 }
 
 /// Number of indices used by [`IndexedColor`].
-pub const INDEXED_COLORS_COUNT: usize = 18;
+pub const INDEXED_COLORS_COUNT: usize = 19;
 
 /// Fallback theme. Matches Windows Terminal's Ottosson theme.
 pub const DEFAULT_THEME: [u32; INDEXED_COLORS_COUNT] = [
     0xff000000, 0xff212cbe, 0xff3aae3f, 0xff4a9abe, 0xffbe4d20, 0xffbe54bb, 0xffb2a700, 0xffbebebe,
     0xff808080, 0xff303eff, 0xff51ea58, 0xff44c9ff, 0xffff6a2f, 0xffff74fc, 0xfff0e100, 0xffffffff,
-    0xff000000, 0xffffffff,
+    0xff000000, 0xffffffff, 0xff000000,
 ];
 
 /// A shoddy framebuffer for terminal applications.


### PR DESCRIPTION
This pull request introduces a new feature to display AI-generated suggestions in the terminal user interface (TUI) and updates the `IndexedColor` enum to support a muted foreground color. The changes primarily focus on enhancing the TUI rendering logic and updating the color palette.

### Enhancements to TUI rendering:

* Added support for displaying AI-generated suggestions (referred to as "ghost text") in the TUI. This includes rendering the suggestions with a muted foreground color and positioning them relative to the cursor and scroll offset. (`src/tui.rs`, [src/tui.rsR914-R944](diffhunk://#diff-99d530b2e5fd9f864743e736b71f188565c40f7881736572bccd3d91e8c6bd30R914-R944))
* Introduced a `suggestion` field to the `TextareaContent` struct to store optional AI-generated suggestion text. (`src/tui.rs`, [src/tui.rsR3544](diffhunk://#diff-99d530b2e5fd9f864743e736b71f188565c40f7881736572bccd3d91e8c6bd30R3544))
* Updated the `Context` initialization to include a placeholder suggestion ("AI completion output here") for demonstration purposes. (`src/tui.rs`, [src/tui.rsR2057](diffhunk://#diff-99d530b2e5fd9f864743e736b71f188565c40f7881736572bccd3d91e8c6bd30R2057))

### Updates to color palette:

* Added a new `MutedForeground` variant to the `IndexedColor` enum and updated the corresponding constant values and theme array to accommodate the new color. (`src/framebuffer.rs`, [src/framebuffer.rsR54-R64](diffhunk://#diff-d8fc83a627d23c6c3579daa21f89364a9740b574901179786916c4bef9980e4eR54-R64))

### Code cleanup:

* Removed an unused import (`std::arch::breakpoint`) from `src/tui.rs`. (`src/tui.rs`, [src/tui.rsL151](diffhunk://#diff-99d530b2e5fd9f864743e736b71f188565c40f7881736572bccd3d91e8c6bd30L151))