### PR TITLE
Remove dependency on `os_string_truncate` nightly feature

### DIFF
--- a/src/bin/edit/main.rs
+++ b/src/bin/edit/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![feature(let_chains, linked_list_cursors, os_string_truncate, string_from_utf8_lossy_owned)]
+#![feature(let_chains, linked_list_cursors, string_from_utf8_lossy_owned)]
 
 mod documents;
 mod draw_editor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
     maybe_uninit_fill,
     maybe_uninit_slice,
     maybe_uninit_uninit_array_transpose,
-    os_string_truncate
 )]
 #![allow(clippy::missing_transmute_annotations, clippy::new_without_default, stable_features)]
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -39,7 +39,7 @@ pub fn normalize(path: &Path) -> PathBuf {
                     // - the provided bytes came directly from a known-to-be-valid `OsStr`, `res`.
                     // - since `parent` is also a valid `OsStr`, trimming at its byte length must also be at a valid
                     //   boundary.
-                    // This is very similar the example given in `OsStr::from_encoded_bytes_unchecked`'s documentation.
+                    // This is very similar to the example from `OsStr::from_encoded_bytes_unchecked`'s documentation.
                     res = PathBuf::from(unsafe { OsString::from_encoded_bytes_unchecked(bytes) });
                 }
             }

--- a/src/path.rs
+++ b/src/path.rs
@@ -40,7 +40,7 @@ pub fn normalize(path: &Path) -> PathBuf {
                     // - since `parent` is also a valid `OsStr`, trimming at its byte length must also be at a valid
                     //   boundary.
                     // This is very similar the example given in `OsStr::from_encoded_bytes_unchecked`'s documentation.
-                    res = unsafe { OsString::from_encoded_bytes_unchecked(bytes).into() };
+                    res = PathBuf::from(unsafe { OsString::from_encoded_bytes_unchecked(bytes) });
                 }
             }
             Component::Normal(p) => res.push(p),


### PR DESCRIPTION
RE: #44, this PR replaces the single use of the `os_string_truncate` feature with a custom stable implementation, trimming down the list of required nightly features by one (1).

This implementation uses a tiny bit of `unsafe`, but from looking at the documentation for [`OsString::into_encoded_bytes()`][osstr_into] and [`OsString::from_encoded_bytes_unchecked()`][osstr_from], I'm reasonably confident that it should be sound. 😄

It's mentioned in [#44](https://github.com/microsoft/edit/issues/44#issuecomment-2891930681) that "shims would go in `src/helpers.rs`," but since the safety of this approach relies on the assumption that the truncated length comes from `parent`, I felt it was better to leave the implementation directly inside of `path::normalize()` (as opposed to an `unsafe fn` with extra safety requirements on a provided `len` paremeter). If that's not desired, perhaps it could be refactored into a shim function in `src/helpers.rs` specifically for trimming a `PathBuf` down to the length of its `.parent()`.

`cargo test path` shows `test_windows` on Win10 and `text_unix` on WSL Ubuntu succeeding as before.

I am interested in looking at some of the other nightly `feature`-gates as well, but this one seemed simple enough to knock out before I went to bed for the night... I've never really contributed to a large project like this, so I'm looking forward to feedback! 🙂

[osstr_from]: https://doc.rust-lang.org/std/ffi/struct.OsString.html#method.from_encoded_bytes_unchecked
[osstr_into]: https://doc.rust-lang.org/std/ffi/struct.OsString.html#method.into_encoded_bytes