### PR TITLE
Add CI action for publishing package to WinGet

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,31 @@
+name: Submit release to the WinGet community repository
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-winget:
+    name: Submit to WinGet repository
+
+    # winget-create is only supported on Windows
+    runs-on: windows-latest
+
+    # Only submit stable releases
+    if: ${{ !github.event.release.prerelease }}
+    steps:
+      - name: Submit package using wingetcreate
+        run: |
+          # Get installer info from release event
+          $assets = '${{ toJSON(github.event.release.assets) }}' | ConvertFrom-Json
+          $x64InstallerUrl = $assets | Where-Object -Property name -like '*x86_64-windows.zip' | Select-Object -ExpandProperty browser_download_url
+          $arm64InstallerUrl = $assets | Where-Object -Property name -like '*aarch64-windows.zip' | Select-Object -ExpandProperty browser_download_url
+          $packageVersion = (${{ toJSON(github.event.release.tag_name) }}).Trim('v')
+
+          # Update package using wingetcreate
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update Microsoft.Edit `
+            --version $packageVersion `
+            --urls $x64InstallerUrl $arm64InstallerUrl `
+            --token "${{ secrets.WINGET_TOKEN }}" `
+            --submit


### PR DESCRIPTION
## Change

Add a GitHub action similar to the [Terminal](https://github.com/microsoft/terminal/blob/main/.github/workflows/winget.yml) one for publishing package to winget-pkgs repository on release. [microsoft/winget-create](https://github.com/microsoft/winget-create) is the tool used for creating and submitting the manifest

## Steps needed from maintainers

Add the a repository secret named `GITHUB_TOKEN` that's a [public access token (classic)](https://github.com/microsoft/winget-create?tab=readme-ov-file#github-personal-access-token-classic-permissions) with [`public_repo`](https://raw.githubusercontent.com/microsoft/winget-create/main/doc/images/tokenscope-publicrepo.png) scope from the user account where the winget-pkgs fork exists (or re-use the terminal's secret to have submissions made from the same bot account @consvc)

