### PR TITLE
Complete Home key toggle functionality between line start and indentation

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2418,6 +2418,14 @@ impl<'a> Context<'a, '_> {
                                 tb.cursor_move_to_logical(indent_end);
                             }
                         }
+                        // If the cursor is at the start of the line (column 0), move it to the indentation position
+                        else if logical_after.x == 0 && indent_end.x > 0 {
+                            if modifiers == kbmod::SHIFT {
+                                tb.selection_update_logical(indent_end);
+                            } else {
+                                tb.cursor_move_to_logical(indent_end);
+                            }
+                        }
                     }
                 }
                 vk::LEFT => {


### PR DESCRIPTION
# Complete Home key toggle functionality  
  
## Problem (#81)
Edit has a "smart home" feature that moves from text to indentation to column 0, but lacks the ability to move from column 0 back to indentation when pressing Home.  
  
## Solution  
This PR completes the bidirectional toggle behavior by adding the missing functionality to move from column 0 to the first non-whitespace character, matching VSCode and Visual Studio behavior.  
  
### Implementation  
- Added condition in Home key handler to check if cursor is at column 0  
- Reuses existing `indent_end_logical_pos()` function  
- Maintains Shift+Home selection support  
  
### Files Changed  
- `src/tui.rs`: Added missing condition in Home key handler  
  
## Testing  
Verified toggle works in both directions with and without selection.