### PR TITLE
Request DEC mode 1036 (Alt+char sends ESC)

### DIFF
--- a/src/bin/edit/main.rs
+++ b/src/bin/edit/main.rs
@@ -491,7 +491,7 @@ impl Drop for RestoreModes {
     fn drop(&mut self) {
         // Same as in the beginning but in the reverse order.
         // It also includes DECSCUSR 0 to reset the cursor style and DECTCEM to show the cursor.
-        sys::write_stdout("\x1b[0 q\x1b[?25h\x1b]0;\x07\x1b[?1002;1006;2004l\x1b[?1049l");
+        sys::write_stdout("\x1b[0 q\x1b[?25h\x1b]0;\x07\x1b[?1036l\x1b[?1002;1006;2004l\x1b[?1049l");
     }
 }
 
@@ -503,7 +503,8 @@ fn setup_terminal(tui: &mut Tui, vt_parser: &mut vt::Parser) -> RestoreModes {
         // 1002: Cell Motion Mouse Tracking
         // 1006: SGR Mouse Mode
         // 2004: Bracketed Paste Mode
-        "\x1b[?1049h\x1b[?1002;1006;2004h",
+        // 1036: Xterm: "meta sends escape" (Alt keypresses should be encoded with ESC + char)
+        "\x1b[?1049h\x1b[?1002;1006;2004h\x1b[?1036h",
         // OSC 4 color table requests for indices 0 through 15 (base colors).
         "\x1b]4;0;?;1;?;2;?;3;?;4;?;5;?;6;?;7;?\x07",
         "\x1b]4;8;?;9;?;10;?;11;?;12;?;13;?;14;?;15;?\x07",


### PR DESCRIPTION
xterm defaults to an 8-bit character encoding for Alt+key presses.

Private mode 1036 temporarily enables the `metaSendsEscape` resource:

`Ps = 1 0 3 6`  ⇒  Send `ESC`   when Meta modifies a key, _xterm_.

Fixes #197