### PR TITLE
Restore the ability to edit a new nonexistent file

### DIFF
--- a/src/bin/edit/documents.rs
+++ b/src/bin/edit/documents.rs
@@ -156,10 +156,10 @@ impl DocumentManager {
             Err(err) => return Err(err),
         };
 
-        let file_id = Some(sys::file_id(file.as_ref(), &path)?);
+        let file_id = if file.is_some() { Some(sys::file_id(file.as_ref(), &path)?) } else { None };
 
         // Check if the file is already open.
-        if self.update_active(|doc| doc.file_id == file_id) {
+        if file_id.is_some() && self.update_active(|doc| doc.file_id == file_id) {
             let doc = self.active_mut().unwrap();
             if let Some(goto) = goto {
                 doc.buffer.borrow_mut().cursor_move_to_logical(goto);


### PR DESCRIPTION
The fix in #193 required us to create FileIds even for nonexistent files.
That broke the creation of nonexistent files.