### PR TITLE
Fix various spelling errors

### DIFF
--- a/src/arena/release.rs
+++ b/src/arena/release.rs
@@ -30,7 +30,7 @@ const ALLOC_CHUNK_SIZE: usize = 64 * KIBI;
 ///
 /// The biggest benefit though is that it sometimes massively simplifies lifetime
 /// and memory management. This can best be seen by this project's UI code, which
-/// uses an arena to allocate a tree of UI nodes. This is infameously difficult
+/// uses an arena to allocate a tree of UI nodes. This is infamously difficult
 /// to do in Rust, but not so when you got an arena allocator:
 /// All nodes have the same lifetime, so you can just use references.
 ///

--- a/src/arena/string.rs
+++ b/src/arena/string.rs
@@ -133,7 +133,7 @@ impl<'a> ArenaString<'a> {
     }
 
     /// Reserves *additional* memory. For you old folks out there (totally not me),
-    /// this is differrent from C++'s `reserve` which reserves a total size.
+    /// this is different from C++'s `reserve` which reserves a total size.
     pub fn reserve(&mut self, additional: usize) {
         self.vec.reserve(additional)
     }

--- a/src/bin/edit/main.rs
+++ b/src/bin/edit/main.rs
@@ -594,7 +594,7 @@ fn setup_terminal(tui: &mut Tui, vt_parser: &mut vt::Parser) -> RestoreModes {
     RestoreModes
 }
 
-/// Strips all C0 control characters from the string an replaces them with "_".
+/// Strips all C0 control characters from the string and replaces them with "_".
 ///
 /// Jury is still out on whether this should also strip C1 control characters.
 /// That requires parsing UTF8 codepoints, which is annoying.

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -1326,7 +1326,7 @@ impl TextBuffer {
                 cursor = self.goto_line_start(cursor, pos.y);
             }
         } else {
-            // `goto_visual()` can only seek foward, so we need to seek backward here if needed.
+            // `goto_visual()` can only seek forward, so we need to seek backward here if needed.
             // NOTE that this intentionally doesn't use the `Eq` trait of `Point`, because if
             // `pos.y == cursor.visual_pos.y` we don't need to go to `cursor.logical_pos.y - 1`.
             while pos.y < cursor.visual_pos.y {

--- a/src/buffer/navigation.rs
+++ b/src/buffer/navigation.rs
@@ -13,7 +13,7 @@ enum CharClass {
     Word,
 }
 
-const fn construct_classifier(seperators: &[u8]) -> [CharClass; 256] {
+const fn construct_classifier(separators: &[u8]) -> [CharClass; 256] {
     let mut classifier = [CharClass::Word; 256];
 
     classifier[b' ' as usize] = CharClass::Whitespace;
@@ -22,9 +22,9 @@ const fn construct_classifier(seperators: &[u8]) -> [CharClass; 256] {
     classifier[b'\r' as usize] = CharClass::Newline;
 
     let mut i = 0;
-    let len = seperators.len();
+    let len = separators.len();
     while i < len {
-        let ch = seperators[i];
+        let ch = separators[i];
         assert!(ch < 128, "Only ASCII separators are supported.");
         classifier[ch as usize] = CharClass::Separator;
         i += 1;
@@ -58,7 +58,7 @@ fn word_navigation<T: WordNavigation>(mut nav: T) -> usize {
     // Skip any whitespace.
     nav.skip_class(CharClass::Whitespace);
 
-    // Skip one word or seperator and take note of the class.
+    // Skip one word or separator and take note of the class.
     let class = nav.peek(CharClass::Whitespace);
     if matches!(class, CharClass::Separator | CharClass::Word) {
         nav.next();

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -101,7 +101,7 @@ pub fn score_fuzzy<'a>(
                     // We don't need to check if it's contiguous if we allow non-contiguous matches
                     allow_non_contiguous_matches ||
                         // We must be looking for a contiguous match.
-                        // Looking at an index higher than 0 in the query means we must have already
+                        // Looking at an index above 0 in the query means we must have already
                         // found out this is contiguous otherwise there wouldn't have been a score
                         query_index > 0 ||
                         // lastly check if the query is completely contiguous at this index in the target

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -74,7 +74,7 @@ pub fn score_fuzzy<'a>(
             let matches_sequence_len =
                 if query_index > 0 && target_index > 0 { matches[diag_index] } else { 0 };
 
-            // If we are not matching on the first query character any more, we only produce a
+            // If we are not matching on the first query character anymore, we only produce a
             // score if we had a score previously for the last query index (by looking at the diagScore).
             // This makes sure that the query always matches in sequence on the target. For example
             // given a target of "ede" and a query of "de", we would otherwise produce a wrong high score

--- a/src/input.rs
+++ b/src/input.rs
@@ -12,7 +12,7 @@ use crate::vt;
 /// Represents a key/modifier combination.
 ///
 /// TODO: Is this a good idea? I did it to allow typing `kbmod::CTRL | vk::A`.
-/// The reason it's an awkard u32 and not a struct is to hopefully make ABIs easier later.
+/// The reason it's an awkward u32 and not a struct is to hopefully make ABIs easier later.
 /// Of course you could just translate on the ABI boundary, but my hope is that this
 /// design lets me realize some restrictions early on that I can't foresee yet.
 #[repr(transparent)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -499,7 +499,7 @@ impl<'input> Stream<'_, '_, 'input> {
     /// ```
     ///
     /// That text inbetween is then expected to be taken literally.
-    /// It can inbetween be anything though, including other escape sequences.
+    /// It can be in between anything though, including other escape sequences.
     /// This is the reason why this is a separate method.
     #[cold]
     fn handle_bracketed_paste(&mut self) -> Option<Input<'input>> {

--- a/src/input.rs
+++ b/src/input.rs
@@ -498,7 +498,7 @@ impl<'input> Stream<'_, '_, 'input> {
     /// <ESC>[201~    lots of text    <ESC>[201~
     /// ```
     ///
-    /// That text inbetween is then expected to be taken literally.
+    /// That in between text is then expected to be taken literally.
     /// It can be in between anything though, including other escape sequences.
     /// This is the reason why this is a separate method.
     #[cold]

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -515,7 +515,7 @@ where
     if suffix.is_empty() {
         name
     } else {
-        // SAFETY: In this particualar case we know that the string
+        // SAFETY: In this particular case we know that the string
         // is valid UTF-8, because it comes from icu.rs.
         let name = unsafe { name.to_str().unwrap_unchecked() };
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -10,7 +10,7 @@
 //! fairly minimal, and for that purpose an immediate mode design is much simpler to use.
 //!
 //! So what's "immediate mode"? The primary alternative is called "retained mode".
-//! The diference is that when you create a button in this framework in one frame,
+//! The difference is that when you create a button in this framework in one frame,
 //! and you stop telling this framework in the next frame, the button will vanish.
 //! When you use a regular retained mode UI framework, you create the button once,
 //! set up callbacks for when it is clicked, and then stop worrying about it.

--- a/src/unicode/measurement.rs
+++ b/src/unicode/measurement.rs
@@ -968,7 +968,7 @@ mod test {
 
         for (y, &expected) in expected.iter().enumerate() {
             let y = y as CoordType;
-            // In order for `goto_visual()` to hit columnn 0 after a word wrap,
+            // In order for `goto_visual()` to hit column 0 after a word wrap,
             // it MUST be able to go back by 1 grapheme, which is what this tests.
             let beg = cfg.goto_visual(Point { x: 0, y });
             let end = cfg.goto_visual(Point { x: 5, y });
@@ -1069,7 +1069,7 @@ mod test {
 
         for (y, &expected) in expected.iter().enumerate() {
             let y = y as CoordType;
-            // In order for `goto_visual()` to hit columnn 0 after a word wrap,
+            // In order for `goto_visual()` to hit column 0 after a word wrap,
             // it MUST be able to go back by 1 grapheme, which is what this tests.
             let beg = cfg.goto_visual(Point { x: 0, y });
             let end = cfg.goto_visual(Point { x: 5, y });

--- a/src/unicode/measurement.rs
+++ b/src/unicode/measurement.rs
@@ -32,7 +32,7 @@ pub struct Cursor {
     pub column: CoordType,
     /// When `measure_forward` hits the `word_wrap_column`, the question is:
     /// Was there a wrap opportunity on this line? Because if there wasn't,
-    /// a hard-wrap is required; otherwise, the word that is being layouted is
+    /// a hard-wrap is required; otherwise, the word that is being laid-out is
     /// moved to the next line. This boolean carries this state between calls.
     pub wrap_opp: bool,
 }
@@ -357,7 +357,7 @@ impl<'doc> MeasurementConfig<'doc> {
         // Is the word we're currently on so wide that it will be wrapped further down the document?
         if word_wrap_column > 0 {
             if !wrap_opp {
-                // If the current layouted line had no wrap opportunities, it means we had an input
+                // If the current laid-out line had no wrap opportunities, it means we had an input
                 // such as "fooooooooooooooooooooo" at a `word_wrap_column` of e.g. 10. The word
                 // didn't fit and the lack of a `wrap_opp` indicates we must force a hard wrap.
                 // Thankfully, if we reach this point, that was already done by the code above.
@@ -944,7 +944,7 @@ mod test {
             }
         );
 
-        // Test if the remaining 4 "a"s are properly layouted.
+        // Test if the remaining 4 "a"s are properly laid-out.
         let end2 = cfg.goto_visual(Point { x: max, y: 2 });
         assert_eq!(
             end2,

--- a/src/unicode/measurement.rs
+++ b/src/unicode/measurement.rs
@@ -32,7 +32,7 @@ pub struct Cursor {
     pub column: CoordType,
     /// When `measure_forward` hits the `word_wrap_column`, the question is:
     /// Was there a wrap opportunity on this line? Because if there wasn't,
-    /// a hard-wrap is required, otherwise the word that is being layouted is
+    /// a hard-wrap is required; otherwise, the word that is being layouted is
     /// moved to the next line. This boolean carries this state between calls.
     pub wrap_opp: bool,
 }

--- a/src/vt.rs
+++ b/src/vt.rs
@@ -80,7 +80,7 @@ impl Parser {
 
     /// Suggests a timeout for the next call to `read()`.
     ///
-    /// We need this because of the ambiguouity of whether a trailing
+    /// We need this because of the ambiguity of whether a trailing
     /// escape character in an input is starting another escape sequence or
     /// is just the result of the user literally pressing the Escape key.
     pub fn read_timeout(&mut self) -> std::time::Duration {

--- a/tools/grapheme-table-gen/src/main.rs
+++ b/tools/grapheme-table-gen/src/main.rs
@@ -243,7 +243,7 @@ const HELP: &str = "\
 Usage: grapheme-table-gen [options...] <ucd.nounihan.grouped.xml>
   -h, --help            Prints help information
   --lang=<c|rust>       Output language (default: c)
-  --extended            Expose a start-of-text property for kickstarting the segmentation
+  --extended            Expose a start-of-text property for kick-starting the segmentation
                         Expose tab and linefeed as grapheme cluster properties
   --no-ambiguous        Treat all ambiguous characters as narrow
   --line-breaks         Store and expose line break information


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling)

The misspellings have been reported at https://github.com/jsoref/microsoft-edit/actions/runs/15175668756/attempts/1#summary-42675376659

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/microsoft-edit/actions/runs/15175668818/attempts/1#summary-42675376754