### PR TITLE
feat: close modals when dimmed background is clicked

### DIFF
--- a/src/bin/edit/draw_editor.rs
+++ b/src/bin/edit/draw_editor.rs
@@ -221,7 +221,7 @@ pub fn draw_handle_wants_close(ctx: &mut Context, state: &mut State) {
     }
     let mut action = Action::None;
 
-    ctx.modal_begin("unsaved-changes", loc(LocId::UnsavedChangesDialogTitle));
+    let bg_click = ctx.modal_begin("unsaved-changes", loc(LocId::UnsavedChangesDialogTitle));
     ctx.attr_background_rgba(ctx.indexed(IndexedColor::Red));
     ctx.attr_foreground_rgba(ctx.indexed(IndexedColor::BrightWhite));
     {
@@ -257,7 +257,7 @@ pub fn draw_handle_wants_close(ctx: &mut Context, state: &mut State) {
         }
         ctx.table_end();
     }
-    if ctx.modal_end() {
+    if ctx.modal_end() || bg_click {
         action = Action::Cancel;
     }
 

--- a/src/bin/edit/draw_filepicker.rs
+++ b/src/bin/edit/draw_filepicker.rs
@@ -30,7 +30,7 @@ pub fn draw_file_picker(ctx: &mut Context, state: &mut State) {
     let mut doit = None;
     let mut done = false;
 
-    ctx.modal_begin(
+    let bg_click = ctx.modal_begin(
         "file-picker",
         if state.wants_file_picker == StateFilePicker::Open {
             loc(LocId::FileOpen)
@@ -122,14 +122,14 @@ pub fn draw_file_picker(ctx: &mut Context, state: &mut State) {
             }
         }
     }
-    if ctx.modal_end() {
+    if ctx.modal_end() || bg_click {
         done = true;
     }
 
     if state.file_picker_overwrite_warning.is_some() {
         let mut save;
 
-        ctx.modal_begin("overwrite", loc(LocId::FileOverwriteWarning));
+        let bg_click = ctx.modal_begin("overwrite", loc(LocId::FileOverwriteWarning));
         ctx.attr_background_rgba(ctx.indexed(IndexedColor::Red));
         ctx.attr_foreground_rgba(ctx.indexed(IndexedColor::BrightWhite));
         {
@@ -160,7 +160,7 @@ pub fn draw_file_picker(ctx: &mut Context, state: &mut State) {
                 state.file_picker_overwrite_warning = None;
             }
         }
-        if ctx.modal_end() {
+        if ctx.modal_end() || bg_click {
             state.file_picker_overwrite_warning = None;
         }
 

--- a/src/bin/edit/draw_menubar.rs
+++ b/src/bin/edit/draw_menubar.rs
@@ -120,7 +120,7 @@ fn draw_menu_help(ctx: &mut Context, state: &mut State) {
 }
 
 pub fn draw_dialog_about(ctx: &mut Context, state: &mut State) {
-    ctx.modal_begin("about", loc(LocId::AboutDialogTitle));
+    let bg_click = ctx.modal_begin("about", loc(LocId::AboutDialogTitle));
     {
         ctx.block_begin("content");
         ctx.inherit_focus();
@@ -160,7 +160,7 @@ pub fn draw_dialog_about(ctx: &mut Context, state: &mut State) {
         }
         ctx.block_end();
     }
-    if ctx.modal_end() {
+    if ctx.modal_end() || bg_click {
         state.wants_about = false;
     }
 }

--- a/src/bin/edit/draw_statusbar.rs
+++ b/src/bin/edit/draw_statusbar.rs
@@ -198,7 +198,7 @@ pub fn draw_dialog_encoding_change(ctx: &mut Context, state: &mut State) {
     let height = (ctx.size().height - 10).max(10);
     let mut change = None;
 
-    ctx.modal_begin(
+    let bg_click = ctx.modal_begin(
         "encode",
         if reopen { loc(LocId::EncodingReopen) } else { loc(LocId::EncodingConvert) },
     );
@@ -223,7 +223,7 @@ pub fn draw_dialog_encoding_change(ctx: &mut Context, state: &mut State) {
         }
         ctx.scrollarea_end();
     }
-    if ctx.modal_end() {
+    if ctx.modal_end() || bg_click {
         state.wants_encoding_change = StateEncodingChange::None;
     }
 
@@ -249,7 +249,7 @@ pub fn draw_dialog_encoding_change(ctx: &mut Context, state: &mut State) {
 }
 
 pub fn draw_document_picker(ctx: &mut Context, state: &mut State) {
-    ctx.modal_begin("document-picker", "");
+    let bg_click = ctx.modal_begin("document-picker", "");
     {
         let width = (ctx.size().width - 20).max(10);
         let height = (ctx.size().height - 10).max(10);
@@ -285,7 +285,7 @@ pub fn draw_document_picker(ctx: &mut Context, state: &mut State) {
         }
         ctx.scrollarea_end();
     }
-    if ctx.modal_end() {
+    if ctx.modal_end() || bg_click {
         state.wants_document_picker = false;
     }
 }

--- a/src/bin/edit/main.rs
+++ b/src/bin/edit/main.rs
@@ -394,7 +394,7 @@ fn draw_handle_clipboard_change(ctx: &mut Context, state: &mut State) {
 
     let over_limit = ctx.clipboard().len() >= SCRATCH_ARENA_CAPACITY / 4;
 
-    ctx.modal_begin("warning", loc(LocId::WarningDialogTitle));
+    let bg_click = ctx.modal_begin("warning", loc(LocId::WarningDialogTitle));
     {
         ctx.block_begin("description");
         ctx.attr_padding(Rect::three(1, 2, 1));
@@ -464,7 +464,7 @@ fn draw_handle_clipboard_change(ctx: &mut Context, state: &mut State) {
         }
         ctx.table_end();
     }
-    if ctx.modal_end() {
+    if ctx.modal_end() || bg_click {
         state.osc_clipboard_seen_generation = generation;
     }
 }
@@ -491,7 +491,9 @@ impl Drop for RestoreModes {
     fn drop(&mut self) {
         // Same as in the beginning but in the reverse order.
         // It also includes DECSCUSR 0 to reset the cursor style and DECTCEM to show the cursor.
-        sys::write_stdout("\x1b[0 q\x1b[?25h\x1b]0;\x07\x1b[?1036l\x1b[?1002;1006;2004l\x1b[?1049l");
+        sys::write_stdout(
+            "\x1b[0 q\x1b[?25h\x1b]0;\x07\x1b[?1036l\x1b[?1002;1006;2004l\x1b[?1049l",
+        );
     }
 }
 

--- a/src/bin/edit/state.rs
+++ b/src/bin/edit/state.rs
@@ -220,7 +220,7 @@ pub fn error_log_add(ctx: &mut Context, state: &mut State, err: apperr::Error) {
 }
 
 pub fn draw_error_log(ctx: &mut Context, state: &mut State) {
-    ctx.modal_begin("error", loc(LocId::ErrorDialogTitle));
+    let bg_click = ctx.modal_begin("error", loc(LocId::ErrorDialogTitle));
     ctx.attr_background_rgba(ctx.indexed(IndexedColor::Red));
     ctx.attr_foreground_rgba(ctx.indexed(IndexedColor::BrightWhite));
     {
@@ -248,7 +248,7 @@ pub fn draw_error_log(ctx: &mut Context, state: &mut State) {
         ctx.attr_position(Position::Center);
         ctx.inherit_focus();
     }
-    if ctx.modal_end() {
+    if ctx.modal_end() || bg_click {
         state.error_log_count = 0;
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1694,12 +1694,15 @@ impl<'a> Context<'a, '_> {
     }
 
     /// Begins a modal window. Call [`Context::modal_end()`].
-    pub fn modal_begin(&mut self, classname: &'static str, title: &str) {
+    pub fn modal_begin(&mut self, classname: &'static str, title: &str) -> bool {
         self.block_begin(classname);
         self.attr_float(FloatSpec { anchor: Anchor::Root, ..Default::default() });
         self.attr_intrinsic_size(Size { width: self.tui.size.width, height: self.tui.size.height });
         self.attr_background_rgba(self.indexed_alpha(IndexedColor::Background, 1, 2));
         self.attr_foreground_rgba(self.indexed_alpha(IndexedColor::Background, 1, 2));
+
+        let bg_click = self.input_mouse_click != 0 && self.was_mouse_down();
+
         self.attr_focus_well();
 
         self.block_begin("window");
@@ -1724,6 +1727,8 @@ impl<'a> Context<'a, '_> {
         };
         last_node.content = NodeContent::Modal(title);
         self.last_modal = Some(self.tree.last_node);
+
+        bg_click
     }
 
     /// Ends the current modal window block.


### PR DESCRIPTION
Runs the same behavior as pressing escape whenever the background of a modal is clicked.