### PR TITLE
Replace a single untitled untouched document on Open

### DIFF
--- a/src/bin/edit/documents.rs
+++ b/src/bin/edit/documents.rs
@@ -194,6 +194,17 @@ impl DocumentManager {
         };
         doc.set_path(path);
 
+        if self.list.len() == 1
+            && let Some(current_doc) = self.list.front()
+            && current_doc.path.is_none()
+            && current_doc.file_id.is_none()
+            && !current_doc.buffer.borrow().is_dirty()
+        {
+            // If there is only one document, and it has no filename, and it is not dirty,
+            // replace it with the new document.
+            self.list.clear();
+        }
+
         self.list.push_front(doc);
         Ok(self.list.front_mut().unwrap())
     }


### PR DESCRIPTION
This may be a controversial opinion.

It felt weird to open edit, open a file, and then see "FILE + 1". I
didn't care about the empty Untitled document, and there was no reason
for it to be kept around.

After this pull request, if you launch edit and then Open a new document
without editing the existing placeholder untitled document or giving it
a name, Edit will close that document and open the new one.

This only applies if there is a single untitled document. If there are
other documents open, we won't close any untitled documents.

We could conceivably expand this behavior to replace *any* untouched
untitled document when you Open a new one.