### PR TITLE
Move `Go to Line/Column` higher in menu

### DIFF
--- a/src/bin/edit/draw_menubar.rs
+++ b/src/bin/edit/draw_menubar.rs
@@ -50,14 +50,14 @@ fn draw_menu_file(ctx: &mut Context, state: &mut State) {
             state.wants_file_picker = StateFilePicker::SaveAs;
         }
     }
+    if ctx.menubar_menu_button(loc(LocId::FileGoto), 'G', kbmod::CTRL | vk::G) {
+        state.wants_goto = true;
+    }
     if ctx.menubar_menu_button(loc(LocId::FileClose), 'C', kbmod::CTRL | vk::W) {
         state.wants_close = true;
     }
     if ctx.menubar_menu_button(loc(LocId::FileExit), 'X', kbmod::CTRL | vk::Q) {
         state.wants_exit = true;
-    }
-    if ctx.menubar_menu_button(loc(LocId::FileGoto), 'G', kbmod::CTRL | vk::G) {
-        state.wants_goto = true;
     }
     ctx.menubar_menu_end();
 }


### PR DESCRIPTION
Closes #261.
# Description
Move `Go to Line/Column` higher in menu. I think that `Close editor` and `Exit` should be last options on menu; other editors do same.
# Screenshots
(In Russian locale)
<img src="https://github.com/user-attachments/assets/d4c3e42c-ac6d-4a87-a18f-8cf4c84a2e54" width="300px"/>
