### PR TITLE
Remove `RUSTC_BOOTSTRAP` recommendation from build guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ This editor pays homage to the classic [MS-DOS Editor](https://en.wikipedia.org/
 
 * [Install Rust](https://www.rust-lang.org/tools/install)
 * Install the nightly toolchain: `rustup install nightly`
-  * Alternatively, set the environment variable `RUSTC_BOOTSTRAP=1`
+* Set nightly as default: `rustup default nightly`
 * Clone the repository
 * For a release build, run: `cargo build --config .cargo/release.toml --release`


### PR DESCRIPTION
Hi! I noticed the build instructions suggest using RUSTC_BOOTSTRAP=1 as an alternative to installing nightly. This flag is actually intended for building Rust itself and can cause unexpected issues with unstable features bleeding through

Since the project already requires nightly anyway, I think we should just remove that line to avoid potential confusion or build problems for new contributors
