### PR TITLE
Scroll single line per VT sequence

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -449,7 +449,7 @@ impl<'input> Iterator for Stream<'_, '_, 'input> {
                             mouse.state = InputMouseState::None;
                             if (btn & 0x40) != 0 {
                                 mouse.state = InputMouseState::Scroll;
-                                mouse.scroll.y += if (btn & 0x01) != 0 { 3 } else { -3 };
+                                mouse.scroll.y += if (btn & 0x01) != 0 { 1 } else { -1 };
                             } else if csi.final_byte == 'M' {
                                 const STATES: [InputMouseState; 4] = [
                                     InputMouseState::Left,


### PR DESCRIPTION
Since the VT scroll sequence predates smooth scrolling increments by decades,  
Edit itself should not have any preconceived notion of interpreting the sequence as a scroll wheel,  
instead the sequence should be treated literally and scroll the text buffer by single lines.

The responsibility amplifying resultant VT scroll sequences based on system preferences  
should be left instead entirely up to the terminal client  
that have knowledge of the incoming hardware scroll inputs,  
instead of the console application which could only interface with VT sequences.