### PR TITLE
Fix a search deadlock if there's no needle

### DIFF
--- a/src/bin/edit/draw_editor.rs
+++ b/src/bin/edit/draw_editor.rs
@@ -125,9 +125,11 @@ fn draw_search(ctx: &mut Context, state: &mut State) {
         ctx.table_begin("options");
         ctx.table_set_cell_gap(Size { width: 2, height: 0 });
         {
+            let mut change = false;
+            let mut change_action = SearchAction::Search;
+
             ctx.table_next_row();
 
-            let mut change = false;
             change |= ctx.checkbox(
                 "match-case",
                 loc(LocId::SearchMatchCase),
@@ -143,20 +145,20 @@ fn draw_search(ctx: &mut Context, state: &mut State) {
                 loc(LocId::SearchUseRegex),
                 &mut state.search_options.use_regex,
             );
-            if change {
-                action = SearchAction::Search;
-                state.wants_search.focus = true;
-                ctx.needs_rerender();
-            }
-
             if state.wants_search.kind == StateSearchKind::Replace
                 && ctx.button("replace-all", loc(LocId::SearchReplaceAll))
             {
-                action = SearchAction::ReplaceAll;
+                change = true;
+                change_action = SearchAction::ReplaceAll;
             }
-
             if ctx.button("close", loc(LocId::SearchClose)) {
                 state.wants_search.kind = StateSearchKind::Hidden;
+            }
+
+            if change {
+                action = change_action;
+                state.wants_search.focus = true;
+                ctx.needs_rerender();
             }
         }
         ctx.table_end();

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -903,7 +903,7 @@ impl TextBuffer {
     }
 
     fn set_selection(&mut self, selection: Option<TextBufferSelection>) -> u32 {
-        self.selection = selection;
+        self.selection = selection.filter(|s| s.beg != s.end);
         self.selection_generation = self.selection_generation.wrapping_add(1);
         self.selection_generation
     }
@@ -1083,6 +1083,10 @@ impl TextBuffer {
         pattern: &str,
         options: SearchOptions,
     ) -> apperr::Result<ActiveSearch> {
+        if pattern.is_empty() {
+            return Err(apperr::Error::Icu(1)); // U_ILLEGAL_ARGUMENT_ERROR
+        }
+
         let sanitized_pattern = if options.whole_word && options.use_regex {
             Cow::Owned(format!(r"\b(?:{pattern})\b"))
         } else if options.whole_word {


### PR DESCRIPTION
This PR fixes the issue twice for double the fun: It now explicitly
checks for a non-empty needle and also ensures the selection is
non-empty which ensures `if !self.has_selection()` works correctly.

Closes #273