### PR TITLE
Fix the bug of  `FilePicker`

### DIFF
--- a/src/bin/edit/draw_filepicker.rs
+++ b/src/bin/edit/draw_filepicker.rs
@@ -114,9 +114,7 @@ pub fn draw_file_picker(ctx: &mut Context, state: &mut State) {
             // Check if the file already exists and show an overwrite warning in that case.
             if state.wants_file_picker != StateFilePicker::Open
                 && let Some(path) = doit.as_deref()
-                && let Some(doc) = state.documents.active()
-                && let Some(file_id) = &doc.file_id
-                && sys::file_id(None, path).is_ok_and(|id| &id == file_id)
+                && std::fs::exists(path).unwrap()
             {
                 state.file_picker_overwrite_warning = doit.take();
             }

--- a/src/bin/edit/draw_filepicker.rs
+++ b/src/bin/edit/draw_filepicker.rs
@@ -9,7 +9,7 @@ use edit::framebuffer::IndexedColor;
 use edit::helpers::*;
 use edit::input::vk;
 use edit::tui::*;
-use edit::{icu, path, sys};
+use edit::{icu, path};
 
 use crate::localization::*;
 use crate::state::*;
@@ -114,7 +114,7 @@ pub fn draw_file_picker(ctx: &mut Context, state: &mut State) {
             // Check if the file already exists and show an overwrite warning in that case.
             if state.wants_file_picker != StateFilePicker::Open
                 && let Some(path) = doit.as_deref()
-                && std::fs::exists(path).unwrap()
+                && path.exists()
             {
                 state.file_picker_overwrite_warning = doit.take();
             }


### PR DESCRIPTION
Bug Fixed.
The `FilePicker` will just replace other files without warning if the doc's name is different from the name entered by the user.