### PR TITLE
chore: Remove unnecessary `let_chains` feature mark

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
     allocator_api,
     breakpoint,
     cold_path,
-    let_chains,
     linked_list_cursors,
     maybe_uninit_fill,
     maybe_uninit_slice,


### PR DESCRIPTION
The `let_chains` feature was stabilized in the `2024` edition of Rust which this project uses, therefore explicitly marking the feature is no longer needed.