### PR TITLE
Close the document as expected

### DIFF
--- a/src/bin/edit/draw_editor.rs
+++ b/src/bin/edit/draw_editor.rs
@@ -187,8 +187,14 @@ fn draw_search(ctx: &mut Context, state: &mut State) {
 pub fn draw_handle_save(ctx: &mut Context, state: &mut State) {
     if let Some(doc) = state.documents.active_mut() {
         if doc.path.is_some() {
-            if let Err(err) = doc.save(None) {
-                error_log_add(ctx, state, err);
+            match doc.save(None) {
+                Ok(_) => {
+                    if state.wants_close_after_save{
+                        state.documents.remove_active();
+                        state.wants_close_after_save = false;
+                    }
+                }
+                Err(err) => error_log_add(ctx, state, err),
             }
         } else {
             // No path? Show the file picker.
@@ -277,7 +283,10 @@ pub fn draw_handle_wants_close(ctx: &mut Context, state: &mut State) {
 
     match action {
         Action::None => return,
-        Action::Save => state.wants_save = true,
+        Action::Save => {
+            state.wants_save = true;
+            state.wants_close_after_save = true;
+        }
         Action::Discard => state.documents.remove_active(),
         Action::Cancel => state.wants_exit = false,
     }

--- a/src/bin/edit/draw_filepicker.rs
+++ b/src/bin/edit/draw_filepicker.rs
@@ -183,6 +183,10 @@ pub fn draw_file_picker(ctx: &mut Context, state: &mut State) {
             Ok(..) => {
                 ctx.needs_rerender();
                 done = true;
+                if state.wants_close_after_save {
+                    state.documents.remove_active();
+                    state.wants_close_after_save = false;
+                }
             }
             Err(err) => error_log_add(ctx, state, err),
         }
@@ -190,6 +194,7 @@ pub fn draw_file_picker(ctx: &mut Context, state: &mut State) {
 
     if done {
         state.wants_file_picker = StateFilePicker::None;
+        state.wants_close_after_save = false;
         state.file_picker_pending_name = Default::default();
         state.file_picker_entries = Default::default();
         state.file_picker_overwrite_warning = Default::default();

--- a/src/bin/edit/state.rs
+++ b/src/bin/edit/state.rs
@@ -143,6 +143,7 @@ pub struct State {
     pub search_success: bool,
 
     pub wants_save: bool,
+    pub wants_close_after_save: bool,
     pub wants_statusbar_focus: bool,
     pub wants_encoding_picker: bool,
     pub wants_encoding_change: StateEncodingChange,
@@ -194,6 +195,7 @@ impl State {
             search_success: true,
 
             wants_save: false,
+            wants_close_after_save: false,
             wants_statusbar_focus: false,
             wants_encoding_picker: false,
             wants_encoding_change: StateEncodingChange::None,


### PR DESCRIPTION
Close the current document when saving via the Unsaved Changes menu, just like the logic of the "Don't Save" button