### PR TITLE
Fix building doc test for `tui` module

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -131,7 +131,7 @@
 //!
 //!         // Thanks to the lack of callbacks, we can use a primitive
 //!         // if condition here, as well as in any potential C code.
-//!         if ctx.button("button", "Click me!") {
+//!         if ctx.button("button", "Click me!", ButtonStyle::default()) {
 //!             state.counter += 1;
 //!         }
 //!


### PR DESCRIPTION
Currently the doc test for `src/tui.rs` fails as follows:

```
---- src\tui.rs - tui (line 91) stdout ----
error[E0061]: this method takes 3 arguments but 2 arguments were supplied
    --> src\tui.rs:135:16
     |
46   |         if ctx.button("button", "Click me!") {
     |                ^^^^^^----------------------- argument #3 of type `ButtonStyle` is missing
     |
note: method defined here
    --> C:\Users\rhysd\Dev\edit\src\tui.rs:1989:12
     |
1989 |     pub fn button(&mut self, classname: &'static str, text: &str, style: ButtonStyle) -> bool {
     |            ^^^^^^
help: provide the argument
     |
46   |         if ctx.button("button", "Click me!", /* ButtonStyle */) {
     |                                            +++++++++++++++++++

error: aborting due to 1 previous error
```

This PR fixes it and I confirmed all other tests passed.