### PR TITLE
Remove unnecessary `let_chain` feature gate

### DIFF
--- a/src/bin/edit/main.rs
+++ b/src/bin/edit/main.rs
@@ -1,13 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![feature(
-    allocator_api,
-    let_chains,
-    linked_list_cursors,
-    os_string_truncate,
-    string_from_utf8_lossy_owned
-)]
+#![feature(allocator_api, linked_list_cursors, os_string_truncate, string_from_utf8_lossy_owned)]
 
 mod documents;
 mod draw_editor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
     allocator_api,
     breakpoint,
     cold_path,
-    let_chains,
     linked_list_cursors,
     maybe_uninit_fill,
     maybe_uninit_slice,


### PR DESCRIPTION
`let_chain` feature was stabilized on April and is available without the feature gate in Rust 2024 now.

Ref: https://github.com/rust-lang/rust/pull/132833