### PR TITLE
chore: fix typos in comment-out

### DIFF
--- a/src/bin/edit/draw_filepicker.rs
+++ b/src/bin/edit/draw_filepicker.rs
@@ -204,7 +204,7 @@ fn draw_file_picker_update_path(state: &mut State) -> Option<PathBuf> {
         // we can detect this by checking if the length of the path didn't change.
         let dir = if cfg!(windows)
             && state.file_picker_pending_name == Path::new("..")
-            // It's unneccessary to check the contents of the paths.
+            // It's unnecessary to check the contents of the paths.
             && old_path.as_os_str().len() == path.as_os_str().len()
         {
             Path::new("")

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -1240,7 +1240,7 @@ impl TextBuffer {
                 self.measurement_config().with_cursor(top).goto_logical(bottom.logical_pos);
 
             // The second problem is that visual positions can be ambiguous. A single logical position
-            // can map to two visual positions: One at the end of the preceeding line in front of
+            // can map to two visual positions: One at the end of the preceding line in front of
             // a word wrap, and another at the start of the next line after the same word wrap.
             //
             // This, however, only applies if we go upwards, because only then `bottom ≅ cursor`,

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -621,7 +621,7 @@ impl LineBuffer {
 
             if left + cursor.visual_pos.x < 0 && cursor.offset < text.len() {
                 // `-left` must've intersected a wide glyph and since goto_visual stops _before_ reaching the target,
-                // we stoped before the wide glyph and thus must step forward to the next glyph.
+                // we stopped before the wide glyph and thus must step forward to the next glyph.
                 cursor = cfg.goto_logical(Point { x: cursor.logical_pos.x + 1, y: 0 });
             }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3207,7 +3207,7 @@ impl<'a> Context<'a, '_> {
         match style.accelerator {
             Some(accelerator) if accelerator.is_ascii_uppercase() => {
                 // Complex case:
-                // Locate the offset of the acclerator character in the label text
+                // Locate the offset of the accelerator character in the label text
                 let mut off = text.len();
                 for (i, c) in text.bytes().enumerate() {
                     // Perfect match (uppercase character) --> stop


### PR DESCRIPTION
fix typos in comment-out