### PR TITLE
Fix scrollbar int overflow in drag handling

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2285,7 +2285,7 @@ impl<'a> Context<'a, '_> {
                             let trackable = track_rect.height() - tc.thumb_height;
                             let delta_y = mouse.y - self.tui.mouse_down_position.y;
                             tc.scroll_offset.y = tc.scroll_offset_y_drag_start
-                                + ((delta_y * scrollable_height) / trackable);
+                                + (delta_y as f32 / trackable as f32 * scrollable_height as f32) as CoordType;
                         }
                     }
                 }
@@ -2812,7 +2812,7 @@ impl<'a> Context<'a, '_> {
                                     let delta_y =
                                         self.tui.mouse_position.y - self.tui.mouse_down_position.y;
                                     sc.scroll_offset.y = sc.scroll_offset_y_drag_start
-                                        + ((delta_y * scrollable_height) / trackable);
+                                        + (delta_y as f32 / trackable as f32 * scrollable_height as f32) as CoordType;
                                 }
 
                                 self.set_input_consumed();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2285,7 +2285,7 @@ impl<'a> Context<'a, '_> {
                             let trackable = track_rect.height() - tc.thumb_height;
                             let delta_y = mouse.y - self.tui.mouse_down_position.y;
                             tc.scroll_offset.y = tc.scroll_offset_y_drag_start
-                                + (delta_y as f32 / trackable as f32 * scrollable_height as f32) as CoordType;
+                                + (delta_y as f64 / trackable as f64 * scrollable_height as f64) as CoordType;
                         }
                     }
                 }
@@ -2812,7 +2812,7 @@ impl<'a> Context<'a, '_> {
                                     let delta_y =
                                         self.tui.mouse_position.y - self.tui.mouse_down_position.y;
                                     sc.scroll_offset.y = sc.scroll_offset_y_drag_start
-                                        + (delta_y as f32 / trackable as f32 * scrollable_height as f32) as CoordType;
+                                        + (delta_y as f64 / trackable as f64 * scrollable_height as f64) as CoordType;
                                 }
 
                                 self.set_input_consumed();


### PR DESCRIPTION
For large files, `delta_y * scrollable_height` can cause an int overflow, resulting in a negative `scroll_offset` and broken behavior. This PR fixes it by casting to f32 for calculation.

## Broken Demo:
Scroll bar doesn't make it to the end of the file and jumps back to 0

https://github.com/user-attachments/assets/70b2c267-8528-4971-bc4e-17a082fd1f02

## Fixed Demo:
Scroll bar continues normally

https://github.com/user-attachments/assets/d470ced9-89a6-4764-9da2-1c3a1fa85022


