### PR TITLE
Avoid CoordType overflow by making it isize

### DIFF
--- a/src/bin/edit/localization.rs
+++ b/src/bin/edit/localization.rs
@@ -469,7 +469,7 @@ const S_LANG_LUT: [[&str; LangId::Count as usize]; LocId::Count as usize] = [
         /* ru      */ "Выделить всё",
         /* zh_hans */ "全选",
         /* zh_hant */ "全選"
-    ]
+    ],
 
     // View (a menu bar item)
     [

--- a/src/bin/edit/main.rs
+++ b/src/bin/edit/main.rs
@@ -207,7 +207,7 @@ fn run() -> apperr::Result<()> {
                 );
 
                 // "μs" is 3 bytes and 2 columns.
-                let cols = status.len() as i32 - 3 + 2;
+                let cols = status.len() as edit::helpers::CoordType - 3 + 2;
 
                 // Since the status may shrink and grow, we may have to overwrite the previous one with whitespace.
                 let padding = (last_latency_width - cols).max(0);

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -41,14 +41,14 @@ impl fmt::Display for MetricFormatter<usize> {
 }
 
 /// A viewport coordinate type used throughout the application.
-pub type CoordType = i32;
+pub type CoordType = isize;
 
-/// To avoid overflow issues because you're adding two [`CoordType::MAX`] values together,
-/// you can use [`COORD_TYPE_SAFE_MIN`] and [`COORD_TYPE_SAFE_MAX`].
-pub const COORD_TYPE_SAFE_MAX: CoordType = 32767;
-
-/// See [`COORD_TYPE_SAFE_MAX`].
-pub const COORD_TYPE_SAFE_MIN: CoordType = -32767 - 1;
+/// To avoid overflow issues because you're adding two [`CoordType::MAX`]
+/// values together, you can use [`COORD_TYPE_SAFE_MAX`] instead.
+///
+/// It equates to half the bits contained in [`CoordType`], which
+/// for instance is 32767 (0x7FFF) when [`CoordType`] is a [`i32`].
+pub const COORD_TYPE_SAFE_MAX: CoordType = (1 << (CoordType::BITS / 2 - 1)) - 1;
 
 /// A 2D point. Uses [`CoordType`].
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
An example for an issue with `i32` can be seen in #315,
but I suspect there's more issues like that elsewhere.