### PR TITLE
Fix syntax error

### DIFF
--- a/src/bin/edit/localization.rs
+++ b/src/bin/edit/localization.rs
@@ -469,8 +469,7 @@ const S_LANG_LUT: [[&str; LangId::Count as usize]; LocId::Count as usize] = [
         /* ru      */ "Выделить всё",
         /* zh_hans */ "全选",
         /* zh_hant */ "全選"
-    ]
-
+    ],
     // View (a menu bar item)
     [
         /* en      */ "View",


### PR DESCRIPTION
Fixes the following compilation error

```
error: expected `;`, found `[`
   --> src/bin/edit/localization.rs:475:5
    |
475 |     [
    |     ^
    |
help: consider adding `;` here
    |
472 |     ];
    |      +
```