### PR TITLE
build: make the build pipeline produce the ZIP

### DIFF
--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -171,7 +171,7 @@ extends:
                 - pwsh: |-
                     $Dest = New-Item -Type Directory "_staging/${env:RELEASE_NAME}"
                     Write-Host "Staging files from ${env:VPACK_ROOT} at $Dest"
-                    Get-ChildItem $env:VPACK_ROOT -Include *.exe, *.pdb | Copy-Item -Destination $Dest -Verbose
+                    Get-ChildItem "${env:VPACK_ROOT}\*" -Include *.exe, *.pdb | Copy-Item -Destination $Dest -Verbose
                     tar.exe -c -v --format=zip -f "$(ob_outputDirectory)\${env:RELEASE_NAME}.zip" -C _staging $env:RELEASE_NAME
                   env:
                     RELEASE_NAME: edit-$(EditVersion)-${{ replace(platform, 'pc-windows-msvc', 'windows') }}

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -169,10 +169,16 @@ extends:
 
               - ${{ each platform in parameters.buildPlatforms }}:
                 - pwsh: |-
-                    $ReleaseName = "edit-$(EditVersion)-${{ replace(platform, 'pc-windows-msvc', 'windows') }}"
-                    $VpackArchName = Switch("${{split(platform, '-')[0]}}") { "x86_64" { "amd64" }; "aarch64" { "arm64" } }
-                    $Dest = New-Item -Type Directory "_staging/${ReleaseName}"
-                    # Copy the signed binaries from the vpack staging folder
-                    Get-ChildItem "$(ob_createvpack_vpackdirectory)/${VpackArchName}" -Include *.exe, *.pdb | Copy-Item -Destination $Dest -Verbose
-                    tar.exe -c -v --format=zip -f "$(ob_outputDirectory)\${ReleaseName}.zip" -C _staging $ReleaseName
+                    $Dest = New-Item -Type Directory "_staging/${env:RELEASE_NAME}"
+                    Write-Host "Staging files from ${env:VPACK_ROOT} at $Dest"
+                    Get-ChildItem $env:VPACK_ROOT -Include *.exe, *.pdb | Copy-Item -Destination $Dest -Verbose
+                    tar.exe -c -v --format=zip -f "$(ob_outputDirectory)\${env:RELEASE_NAME}.zip" -C _staging $env:RELEASE_NAME
+                  env:
+                    RELEASE_NAME: edit-$(EditVersion)-${{ replace(platform, 'pc-windows-msvc', 'windows') }}
+                    ${{ if eq(platform, 'i686-pc-windows-msvc') }}:
+                      VPACK_ROOT: "$(ob_createvpack_vpackdirectory)/i386"
+                    ${{ elseif eq(platform, 'x86_64-pc-windows-msvc') }}:
+                      VPACK_ROOT: "$(ob_createvpack_vpackdirectory)/amd64"
+                    ${{ else }}: # aarch64-pc-windows-msvc
+                      VPACK_ROOT: "$(ob_createvpack_vpackdirectory)/arm64"
                   displayName: Produce ${{platform}} release archive

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -169,7 +169,7 @@ extends:
 
               - ${{ each platform in parameters.buildPlatforms }}:
                 - pwsh: |-
-                    $ReleaseName = "edit-$(EditVersion)-${{ replace(platform, 'pc-windows-msvc', 'windows' }}"
+                    $ReleaseName = "edit-$(EditVersion)-${{ replace(platform, 'pc-windows-msvc', 'windows') }}"
                     $VpackArchName = Switch("${{split(platform, '-')[0]}}") { "x86_64" { "amd64" }; "aarch64" { "arm64" } }
                     $Dest = New-Item -Type Directory _staging/$ReleaseName
                     # Copy the signed binaries from the vpack staging folder

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -166,3 +166,13 @@ extends:
                   search_root: "$(ob_createvpack_vpackdirectory)"
                   use_testsign: false
                   in_container: true
+
+              - ${{ each platform in parameters.buildPlatforms }}:
+                - pwsh: |-
+                    $ReleaseName = "edit-$(EditVersion)-${{ replace(platform, 'pc-windows-msvc', 'windows' }}"
+                    $VpackArchName = Switch("${{split(platform, '-')[0]}}") { "x86_64" { "amd64" }; "aarch64" { "arm64" } }
+                    $Dest = New-Item -Type Directory _staging/$ReleaseName
+                    # Copy the signed binaries from the vpack staging folder
+                    Get-ChildItem "$(ob_createvpack_vpackdirectory)/$VpackArchName" -Include *.exe, *.pdb | Copy-Item -Destination $Dest -Verbose
+                    tar.exe -c -v --format=zip -f $(ob_outputDirectory)\$(ReleaseName).zip -C _staging $ReleaseName
+                  displayName: Produce ${{platform}} release archive

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -171,8 +171,8 @@ extends:
                 - pwsh: |-
                     $ReleaseName = "edit-$(EditVersion)-${{ replace(platform, 'pc-windows-msvc', 'windows') }}"
                     $VpackArchName = Switch("${{split(platform, '-')[0]}}") { "x86_64" { "amd64" }; "aarch64" { "arm64" } }
-                    $Dest = New-Item -Type Directory _staging/$ReleaseName
+                    $Dest = New-Item -Type Directory "_staging/${ReleaseName}"
                     # Copy the signed binaries from the vpack staging folder
-                    Get-ChildItem "$(ob_createvpack_vpackdirectory)/$VpackArchName" -Include *.exe, *.pdb | Copy-Item -Destination $Dest -Verbose
-                    tar.exe -c -v --format=zip -f $(ob_outputDirectory)\$(ReleaseName).zip -C _staging $ReleaseName
+                    Get-ChildItem "$(ob_createvpack_vpackdirectory)/${VpackArchName}" -Include *.exe, *.pdb | Copy-Item -Destination $Dest -Verbose
+                    tar.exe -c -v --format=zip -f "$(ob_outputDirectory)\${ReleaseName}.zip" -C _staging $ReleaseName
                   displayName: Produce ${{platform}} release archive


### PR DESCRIPTION
Perhaps the next time we make a release, Windows Defender won't consider it a virus?