### PR TITLE
Remove redundant heap allocation in `DisplayablePathBuf::from_string`

### DIFF
--- a/src/bin/edit/state.rs
+++ b/src/bin/edit/state.rs
@@ -42,8 +42,7 @@ pub struct DisplayablePathBuf {
 impl DisplayablePathBuf {
     #[allow(dead_code, reason = "only used on Windows")]
     pub fn from_string(str: String) -> Self {
-        let value = PathBuf::from(&str);
-        Self { value, str: Cow::Owned(str) }
+        Self::from_path(PathBuf::from(str))
     }
 
     pub fn from_path(value: PathBuf) -> Self {

--- a/src/bin/edit/state.rs
+++ b/src/bin/edit/state.rs
@@ -42,7 +42,10 @@ pub struct DisplayablePathBuf {
 impl DisplayablePathBuf {
     #[allow(dead_code, reason = "only used on Windows")]
     pub fn from_string(str: String) -> Self {
-        Self::from_path(PathBuf::from(str))
+        let cow = Cow::Borrowed(str.as_str());
+        let cow = unsafe { mem::transmute::<Cow<'_, str>, Cow<'_, str>>(cow) };
+        let value = PathBuf::from(str);
+        Self { value, str: cow }
     }
 
     pub fn from_path(value: PathBuf) -> Self {

--- a/src/bin/edit/state.rs
+++ b/src/bin/edit/state.rs
@@ -41,11 +41,11 @@ pub struct DisplayablePathBuf {
 
 impl DisplayablePathBuf {
     #[allow(dead_code, reason = "only used on Windows")]
-    pub fn from_string(str: String) -> Self {
-        let cow = Cow::Borrowed(str.as_str());
-        let cow = unsafe { mem::transmute::<Cow<'_, str>, Cow<'_, str>>(cow) };
-        let value = PathBuf::from(str);
-        Self { value, str: cow }
+    pub fn from_string(string: String) -> Self {
+        let str = Cow::Borrowed(string.as_str());
+        let str = unsafe { mem::transmute::<Cow<'_, str>, Cow<'_, str>>(str) };
+        let value = PathBuf::from(string);
+        Self { value, str }
     }
 
     pub fn from_path(value: PathBuf) -> Self {


### PR DESCRIPTION
 `DisplayablePathBuf::from_string` allocates two heap memories for `PathBuf` and `Cow::Owned`. However it can be stored as `Cow::Borrowed` because `String` guarantees UTF-8 sequence. This can remove one redundant heap allocation. ~~As a bonus `DisplayablePathBuf::from_path` can be reused so the code is more simplified.~~