### PR TITLE
ci: rename and add [push] to triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
-name: PR Check
+name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
I think this workflow needs to run on push to `main` _as well as_ pull request to main so that it shows up as an available branch protection status check.

Given that it's not just PRs any longer, I renamed it too.