### PR TITLE
buffer: show control char visualizers in yellow

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -1655,27 +1655,24 @@ impl TextBuffer {
                             // Our manually constructed UTF8 is never going to be invalid. Trust.
                             line.push_str(unsafe { str::from_utf8_unchecked(&visualizer_buf) });
 
-                            let cursor_visualizer = self.cursor_move_to_offset_internal(
-                                cursor_beg,
-                                global_off + chunk_off - 1,
-                            );
-                            let mut visualizer_rect = Rect::two(
-                                destination.top + cursor_visualizer.visual_pos.y - origin.y,
-                                destination.left
+                            let visualizer_rect = {
+                                let cursor_visualizer = self.cursor_move_to_offset_internal(
+                                    cursor_beg,
+                                    global_off + chunk_off - 1,
+                                );
+                                let left = destination.left
                                     + self.margin_width
                                     + cursor_visualizer.visual_pos.x
-                                    - origin.x,
-                            );
-                            visualizer_rect.right += 1;
-                            visualizer_rect.bottom += 1;
-                            if visualizer_rect.top >= destination.top
-                                && visualizer_rect.left >= destination.left
-                            {
-                                let bg = fb.indexed(IndexedColor::Yellow);
-                                let fg = fb.contrasted(bg);
-                                fb.blend_bg(visualizer_rect, bg);
-                                fb.blend_fg(visualizer_rect, fg);
-                            }
+                                    - origin.x;
+                                let top =
+                                    destination.top + cursor_visualizer.visual_pos.y - origin.y;
+                                Rect { left, top, right: left + 1, bottom: top + 1 }
+                            };
+
+                            let bg = fb.indexed(IndexedColor::Yellow);
+                            let fg = fb.contrasted(bg);
+                            fb.blend_bg(visualizer_rect, bg);
+                            fb.blend_fg(visualizer_rect, fg);
                         }
                     }
 

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -1654,6 +1654,27 @@ impl TextBuffer {
                             };
                             // Our manually constructed UTF8 is never going to be invalid. Trust.
                             line.push_str(unsafe { str::from_utf8_unchecked(&visualizer_buf) });
+
+                            let cursor_visualizer = self.cursor_move_to_offset_internal(
+                                cursor_beg,
+                                global_off + chunk_off + 1,
+                            );
+                            let mut visualizer_rect = Rect::two(
+                                destination.top + cursor_visualizer.visual_pos.y,
+                                destination.left
+                                    + self.margin_width
+                                    + cursor_visualizer.visual_pos.x,
+                            );
+                            visualizer_rect.right += 1;
+                            visualizer_rect.bottom += 1;
+                            fb.blend_bg(
+                                visualizer_rect,
+                                fb.indexed_alpha(IndexedColor::Red, 3, 3),
+                            );
+                            fb.blend_fg(
+                                visualizer_rect,
+                                fb.indexed_alpha(IndexedColor::BrightWhite, 3, 3),
+                            );
                         }
                     }
 

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -1657,24 +1657,25 @@ impl TextBuffer {
 
                             let cursor_visualizer = self.cursor_move_to_offset_internal(
                                 cursor_beg,
-                                global_off + chunk_off + 1,
+                                global_off + chunk_off - 1,
                             );
                             let mut visualizer_rect = Rect::two(
-                                destination.top + cursor_visualizer.visual_pos.y,
+                                destination.top + cursor_visualizer.visual_pos.y - origin.y,
                                 destination.left
                                     + self.margin_width
-                                    + cursor_visualizer.visual_pos.x,
+                                    + cursor_visualizer.visual_pos.x
+                                    - origin.x,
                             );
                             visualizer_rect.right += 1;
                             visualizer_rect.bottom += 1;
-                            fb.blend_bg(
-                                visualizer_rect,
-                                fb.indexed_alpha(IndexedColor::Red, 3, 3),
-                            );
-                            fb.blend_fg(
-                                visualizer_rect,
-                                fb.indexed_alpha(IndexedColor::BrightWhite, 3, 3),
-                            );
+                            if visualizer_rect.top >= destination.top
+                                && visualizer_rect.left >= destination.left
+                            {
+                                let bg = fb.indexed(IndexedColor::Yellow);
+                                let fg = fb.contrasted(bg);
+                                fb.blend_bg(visualizer_rect, bg);
+                                fb.blend_fg(visualizer_rect, fg);
+                            }
                         }
                     }
 


### PR DESCRIPTION
This may be controversial, because it is *quite garish*.

![image](https://github.com/user-attachments/assets/956b4844-6c6a-4ddd-b070-9a573751d476)

![image](https://github.com/user-attachments/assets/4af3b53a-b0ea-4b0e-9821-cee3d2affe67)

![image](https://github.com/user-attachments/assets/753ec394-172e-4f88-95a6-88d91aaec6d6)

real U+2400 characters on the left, "visualized" control chars on the right

![image](https://github.com/user-attachments/assets/5d1123af-4257-4e31-bbe6-3d52c4821ebb)
