### PR TITLE
Switch `BackingBuffer::VirtualMemory` to Safe `Box<[u8]>` Backing

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "nightly"
+# Doesn't have to be this toolchain but I pinned it down to a concrete one because not all features required to build this crate are availible on all versions of nightly
+channel = "nightly-2025-04-15"

--- a/src/buffer/gap_buffer.rs
+++ b/src/buffer/gap_buffer.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use std::alloc::{Allocator, Layout};
 use std::ops::Range;
-use std::ptr::{self, NonNull};
-use std::slice;
+use std::ptr::NonNull;
 
+use super::virtual_mem::{VALLOCATOR, VirtualAllocator};
 use crate::document::{ReadableDocument, WriteableDocument};
 use crate::helpers::*;
 use crate::{apperr, sys};
@@ -23,18 +24,8 @@ const SMALL_GAP_CHUNK: usize = 16;
 // TODO: Instead of having a specialization for small buffers here,
 // tui.rs could also just keep a MRU set of large buffers around.
 enum BackingBuffer {
-    VirtualMemory(NonNull<u8>, usize),
+    VirtualMemory(Box<[u8], VirtualAllocator>),
     Vec(Vec<u8>),
-}
-
-impl Drop for BackingBuffer {
-    fn drop(&mut self) {
-        unsafe {
-            if let Self::VirtualMemory(ptr, reserve) = *self {
-                sys::virtual_release(ptr, reserve);
-            }
-        }
-    }
 }
 
 /// Most people know how Vec<T> works: It has some spare capacity at the end,
@@ -42,8 +33,6 @@ impl Drop for BackingBuffer {
 /// is the same thing, but the spare capacity can be anywhere in the buffer.
 /// This variant is optimized for large buffers and uses virtual memory.
 pub struct GapBuffer {
-    /// Pointer to the buffer.
-    text: NonNull<u8>,
     /// Maximum size of the buffer, including gap.
     reserve: usize,
     /// Size of the buffer, including gap.
@@ -65,20 +54,22 @@ impl GapBuffer {
     pub fn new(small: bool) -> apperr::Result<Self> {
         let reserve;
         let buffer;
-        let text;
 
         if small {
             reserve = SMALL_CAPACITY;
-            text = NonNull::dangling();
             buffer = BackingBuffer::Vec(Vec::new());
         } else {
             reserve = LARGE_CAPACITY;
-            text = unsafe { sys::virtual_reserve(reserve)? };
-            buffer = BackingBuffer::VirtualMemory(text, reserve);
+            let ptr = unsafe {
+                VALLOCATOR
+                    .allocate(Layout::from_size_align_unchecked(LARGE_CAPACITY, align_of::<u8>()))
+                    .unwrap()
+            };
+            let buf = unsafe { Box::from_non_null_in(ptr, VALLOCATOR) };
+            buffer = BackingBuffer::VirtualMemory(buf);
         }
 
         Ok(Self {
-            text,
             reserve,
             commit: 0,
             text_length: 0,
@@ -124,7 +115,11 @@ impl GapBuffer {
         }
 
         self.generation = self.generation.wrapping_add(1);
-        unsafe { slice::from_raw_parts_mut(self.text.add(self.gap_off).as_ptr(), self.gap_len) }
+
+        match &mut self.buffer {
+            BackingBuffer::VirtualMemory(buf) => &mut buf[off..off + self.gap_len],
+            BackingBuffer::Vec(buf) => &mut buf[self.gap_off..self.gap_off + self.gap_len],
+        }
     }
 
     fn move_gap(&mut self, off: usize) {
@@ -147,11 +142,29 @@ impl GapBuffer {
             let move_dst = if left { off + self.gap_len } else { self.gap_off };
             let move_len = if left { self.gap_off - off } else { off - self.gap_off };
 
-            unsafe { self.text.add(move_src).copy_to(self.text.add(move_dst), move_len) };
+            match &mut self.buffer {
+                BackingBuffer::VirtualMemory(buf) => {
+                    buf.copy_within(move_src..move_src + move_len, move_dst)
+                }
+                BackingBuffer::Vec(vec) => vec.copy_within(move_src..move_src + move_len, move_dst),
+            }
 
             if cfg!(debug_assertions) {
                 // Fill the moved-out bytes with 0xCD to make debugging easier.
-                unsafe { self.text.add(off).write_bytes(0xCD, self.gap_len) };
+                let start = self.gap_off;
+                let end = start + self.gap_len;
+                match &mut self.buffer {
+                    BackingBuffer::VirtualMemory(buf) => {
+                        for i in start..end {
+                            buf[i] = 0;
+                        }
+                    }
+                    BackingBuffer::Vec(buf) => {
+                        for i in start..end {
+                            buf[i] = 0;
+                        }
+                    }
+                }
             }
         }
 
@@ -161,7 +174,18 @@ impl GapBuffer {
     fn delete_text(&mut self, delete: usize) {
         if cfg!(debug_assertions) {
             // Fill the deleted bytes with 0xCD to make debugging easier.
-            unsafe { self.text.add(self.gap_off + self.gap_len).write_bytes(0xCD, delete) };
+            match &mut self.buffer {
+                BackingBuffer::VirtualMemory(buf) => {
+                    for i in self.gap_off + self.gap_len..delete {
+                        buf[i] = 0;
+                    }
+                }
+                BackingBuffer::Vec(buf) => {
+                    for i in self.gap_off + self.gap_len..delete {
+                        buf[i] = 0;
+                    }
+                }
+            }
         }
 
         self.gap_len += delete;
@@ -194,32 +218,56 @@ impl GapBuffer {
             }
 
             match &mut self.buffer {
-                BackingBuffer::VirtualMemory(ptr, _) => unsafe {
-                    if sys::virtual_commit(ptr.add(bytes_old), bytes_new - bytes_old).is_err() {
+                BackingBuffer::VirtualMemory(buf) => unsafe {
+                    // This function appears to expand the range of the initiallized memory past the boundries of the new gap
+                    // iow I guess it's notifying the program that the bytes after the gap are initialized because the were not previously
+                    if sys::virtual_commit(
+                        NonNull::new_unchecked(buf.as_mut_ptr()).add(bytes_old),
+                        bytes_new - bytes_old,
+                    )
+                    .is_err()
+                    {
                         return;
                     }
                 },
-                BackingBuffer::Vec(v) => {
-                    v.resize(bytes_new, 0);
-                    self.text = unsafe { NonNull::new_unchecked(v.as_mut_ptr()) };
+                BackingBuffer::Vec(buf) => {
+                    buf.resize(bytes_new, 0);
                 }
             }
 
             self.commit = bytes_new;
         }
 
-        let gap_beg = unsafe { self.text.add(self.gap_off) };
-        unsafe {
-            ptr::copy(
-                gap_beg.add(gap_len_old).as_ptr(),
-                gap_beg.add(gap_len_new).as_ptr(),
-                self.text_length - self.gap_off,
-            )
+        // When the gap expands, it will consume the contents bordering it.
+        // Those contents need to be moved out of the newly enlarged gap
+        let gap_end_old = self.gap_off + gap_len_old;
+        let gap_len_new = self.gap_off + gap_len_new;
+        let buf_contents_len = self.text_length - self.gap_off;
+        match &mut self.buffer {
+            BackingBuffer::VirtualMemory(buf) => {
+                buf.copy_within(gap_end_old..gap_end_old + buf_contents_len, gap_len_new);
+            }
+            BackingBuffer::Vec(buf) => {
+                buf.copy_within(gap_end_old..gap_end_old + buf_contents_len, gap_len_new);
+            }
         };
 
         if cfg!(debug_assertions) {
+            let start = self.gap_off + gap_len_old;
+            let end = start + gap_len_new - gap_len_old;
             // Fill the moved-out bytes with 0xCD to make debugging easier.
-            unsafe { gap_beg.add(gap_len_old).write_bytes(0xCD, gap_len_new - gap_len_old) };
+            match &mut self.buffer {
+                BackingBuffer::VirtualMemory(buf) => {
+                    for i in start..end {
+                        buf[i] = 0;
+                    }
+                }
+                BackingBuffer::Vec(buf) => {
+                    for i in start..end {
+                        buf[i] = 0;
+                    }
+                }
+            }
         }
 
         self.gap_len = gap_len_new;
@@ -352,7 +400,10 @@ impl ReadableDocument for GapBuffer {
             len = self.text_length - off;
         }
 
-        unsafe { slice::from_raw_parts(self.text.add(beg).as_ptr(), len) }
+        match &self.buffer {
+            BackingBuffer::VirtualMemory(buf) => &buf[beg..beg + len],
+            BackingBuffer::Vec(buf) => &buf[beg..beg + len],
+        }
     }
 
     fn read_backward(&self, off: usize) -> &[u8] {
@@ -372,6 +423,9 @@ impl ReadableDocument for GapBuffer {
             len = off - self.gap_off;
         }
 
-        unsafe { slice::from_raw_parts(self.text.add(beg).as_ptr(), len) }
+        match &self.buffer {
+            BackingBuffer::VirtualMemory(buf) => &buf[beg..beg + len],
+            BackingBuffer::Vec(buf) => &buf[beg..beg + len],
+        }
     }
 }

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -22,6 +22,7 @@
 
 mod gap_buffer;
 mod navigation;
+mod virtual_mem;
 
 use std::borrow::Cow;
 use std::cell::UnsafeCell;

--- a/src/buffer/virtual_mem.rs
+++ b/src/buffer/virtual_mem.rs
@@ -1,0 +1,53 @@
+use std::alloc::{AllocError, Allocator, Layout};
+use std::ptr::{self, NonNull};
+
+use crate::sys;
+
+/// The virtual system allocator backed by [`VirtualAlloc`](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualalloc).
+pub static VALLOCATOR: VirtualAllocator = VirtualAllocator;
+
+#[derive(Debug, Clone, Copy)]
+pub struct VirtualAllocator;
+
+unsafe impl Allocator for VirtualAllocator {
+    /// Attempts to allocate a block of virtual memory.
+    ///
+    /// On success, returns a [`NonNull<[u8]>`][NonNull] meeting the size and alignment guarantees of `layout`.
+    ///
+    /// The returned block may have a larger size than specified by `layout.size()`, and may or may
+    /// not have its contents initialized.
+    ///
+    /// The returned block of memory remains valid as long as it is [*currently allocated*] and the shorter of:
+    ///   - the borrow-checker lifetime of the allocator type itself.
+    ///   - as long as at the allocator and all its clones has not been dropped.
+    ///
+    /// # Warning
+    /// The returned block of memory has not been commited. Attempting to use the block of memory without commiting it will cause a `STATUS_ACCESS_VIOLATION`.
+    ///
+    /// # Errors
+    ///
+    /// Returning `Err` indicates that either memory is exhausted or `layout` does not meet
+    /// allocator's size or alignment constraints.
+    ///
+    /// Implementations are encouraged to return `Err` on memory exhaustion rather than panicking or
+    /// aborting, but this is not a strict requirement. (Specifically: it is *legal* to implement
+    /// this trait atop an underlying native allocation library that aborts on memory exhaustion.)
+    ///
+    /// Clients wishing to abort computation in response to an allocation error are encouraged to
+    /// call the [`handle_alloc_error`] function, rather than directly invoking `panic!` or similar.
+    ///
+    /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let size = layout.size();
+        unsafe {
+            match sys::virtual_reserve(size) {
+                Ok(ptr) => Ok(NonNull::new_unchecked(ptr::from_raw_parts_mut(ptr.as_ptr(), size))),
+                Err(_) => Err(AllocError),
+            }
+        }
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        unsafe { sys::virtual_release(ptr, layout.size()) };
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,9 @@
     maybe_uninit_fill,
     maybe_uninit_slice,
     maybe_uninit_uninit_array_transpose,
-    os_string_truncate
+    os_string_truncate,
+    box_vec_non_null,
+    ptr_metadata
 )]
 #![allow(clippy::missing_transmute_annotations, clippy::new_without_default, stable_features)]
 

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -482,6 +482,10 @@ pub fn canonicalize(path: &Path) -> std::io::Result<PathBuf> {
 /// To commit the memory, use [`virtual_commit`].
 /// To release the memory, use [`virtual_release`].
 ///
+/// # Warning
+/// The pointer returned by this function must be committed before use. Attempting to access [uncommited](https://learn.microsoft.com/en-us/windows/win32/Memory/page-state) memory is a status access violation.
+///
+///
 /// # Safety
 ///
 /// This function is unsafe because it uses raw pointers.


### PR DESCRIPTION
# Motivation
This PR addresses concerns raised in [#359](https://github.com/microsoft/edit/issues/359) about the safety and maintainability of manually managed virtual memory using `NonNull<u8>` and pointer arithmetic. By switching to `Box<[u8]>`, we maintain similar memory semantics while gaining safety and reducing code complexity.

## Main Changes
- Used a `Box<[u8]>` for the contents of `BackingBuffer::VirtualMemory` instead of a `NonNull`.
- Unsafe blocks are now limited to system-level allocation/deallocation and bounds-checked access is the default.
- Removed most manual pointer arithmetic and unsafe dereferencing in favor of slice indexing.
- Switching to `Box<[u8]>` also allowed me to remove the `text` field from `GapBuffer` which reduces the size of the struct.


## Miscellaneous changes
- Pinned down the toolchain to `nightly-2025-04-15` as not all features required to build this crate are available on all versions of nightly.
- Added line to clarify `virtual_release` returns memory which will error if accessed before [committed](https://learn.microsoft.com/en-us/windows/win32/Memory/page-state).

# Results
Benchmarks were obtained by running `cargo bench --bench lib -- --save-baseline before` on main and `cargo bench --bench lib -- --save-baseline box-raw-alloc` on my branch. Results were then exported to JSON and compared using `critcmp before.json box-raw-alloc.json --list`. See [before.json (https://drive.google.com/file/d/1krzmBTmidI8jgXu08EAo_FelmFmKP2i-/view?usp=drive_link) and [box-raw-alloc.json](https://drive.google.com/file/d/1rwud47HCDTiGTh9jqEPtWSChIXiVJqst/view?usp=sharing).

- Benchmarks show no statistically significant regression in performance, despite the shift to safe abstractions.
- Binary size is 1kb smaller than the current release build on [my machine](https://drive.google.com/file/d/1Ey73e8h9G1L4fmR0cyWgGshcr7QfyGWX/view?usp=drive_link) and 20kb smaller than the download.
- All existing tests pass. No regressions were found during local testing.