### PR TITLE
Fix `Vec<T>` formatting in docs

### DIFF
--- a/src/buffer/gap_buffer.rs
+++ b/src/buffer/gap_buffer.rs
@@ -37,7 +37,7 @@ impl Drop for BackingBuffer {
     }
 }
 
-/// Most people know how Vec<T> works: It has some spare capacity at the end,
+/// Most people know how `Vec<T>` works: It has some spare capacity at the end,
 /// so that pushing into it doesn't reallocate every single time. A gap buffer
 /// is the same thing, but the spare capacity can be anywhere in the buffer.
 /// This variant is optimized for large buffers and uses virtual memory.


### PR DESCRIPTION
marking `Vec<T>` as source code, not HTML tag
![image](https://github.com/user-attachments/assets/84bf20db-26d4-4f09-b512-cbe5d03cdb6d)
