### PR TITLE
Allow activating previous position in listing for file picker

### DIFF
--- a/src/bin/edit/draw_filepicker.rs
+++ b/src/bin/edit/draw_filepicker.rs
@@ -96,7 +96,7 @@ pub fn draw_file_picker(ctx: &mut Context, state: &mut State) {
                     ListSelection::Activated => {
                         state.file_picker_pending_name = entry.as_path().into();
                         activated = true
-                    },
+                    }
                 }
                 ctx.attr_overflow(Overflow::TruncateMiddle);
             }


### PR DESCRIPTION
Selection position is preserved across directory traversal today. Activating at the same position after traversal doesn't work because the current implementation expects a "select" before "activate".

Fixed by setting file_picker_pending_name in the Activated callback to allow users to activate a list item that was pre-selected from a previous screen.

Video:
https://github.com/user-attachments/assets/e2657c77-e66a-428f-a20f-91815daa58ba

An alternative fix could be to reset the selection to default or the first node (i.e. `..`)

#347 