### PR TITLE
Allow find and replace with an empty string

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -1071,7 +1071,11 @@ impl TextBuffer {
         if let (Some(search), Some(..)) = (&mut self.search, &self.selection) {
             let search = search.get_mut();
             if search.selection_generation == self.selection_generation {
-                self.write(replacement.as_bytes(), true);
+                if replacement.is_empty() {
+                    self.extract_selection(true);
+                } else {
+                    self.write(replacement.as_bytes(), true);
+                }
             }
         }
 
@@ -1094,7 +1098,11 @@ impl TextBuffer {
             if !self.has_selection() {
                 break;
             }
-            self.write(replacement, true);
+            if replacement.is_empty() {
+                self.extract_selection(true);
+            } else {
+                self.write(replacement, true);
+            }
             offset = self.cursor.offset;
         }
 


### PR DESCRIPTION
Currently if the replace field is empty, the write function will do nothing, and hitting enter will simply go through the occurrences replacing nothing.

Allowing the replace string to be empty, allows the user to use find and replace to rapidly erase text.

Since write specifically checks if string is empty, we could consider allowing an empty write, which does work in testing, but we can instead utilise extract_selection here instead. This is a bit more explicit and ensures this change only affects find and replace.

Closes #439