### PR TITLE
Add a CodeLLDB launch option for VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,17 @@
             "args": [
                 "${workspaceFolder}/src/bin/edit/main.rs"
             ],
+        },
+        {
+            "name": "Launch Debug (LLDB)",
+            "preLaunchTask": "rust: cargo build",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceFolder}/target/debug/edit",
+            "cwd": "${workspaceFolder}",
+            "args": [
+                "${workspaceFolder}/src/bin/edit/main.rs"
+            ],
         }
     ]
 }


### PR DESCRIPTION
CodeLLDB is the second most popular extension for debugging with LLDB in VSCode, so I think it would be useful for a lot of people to add a launch option for it as well.