### PR TITLE
Add cursor display option via View menu

### DIFF
--- a/src/bin/edit/draw_editor.rs
+++ b/src/bin/edit/draw_editor.rs
@@ -26,6 +26,13 @@ pub fn draw_editor(ctx: &mut Context, state: &mut State) {
     };
 
     if let Some(doc) = state.documents.active() {
+        // Match the application state
+        {
+            let mut buffer = doc.buffer.borrow_mut();
+            let cursor_style = state.cursor_style.to_decscusr_code(buffer.is_overtype());
+            buffer.set_cursor_style(cursor_style);
+        }
+        
         ctx.textarea("textarea", doc.buffer.clone());
         ctx.inherit_focus();
     } else {

--- a/src/bin/edit/draw_filepicker.rs
+++ b/src/bin/edit/draw_filepicker.rs
@@ -241,7 +241,7 @@ pub fn draw_file_picker(ctx: &mut Context, state: &mut State) {
 
     if let Some(path) = doit {
         let res = if state.wants_file_picker == StateFilePicker::Open {
-            state.documents.add_file_path(&path).map(|_| ())
+            state.documents.add_file_path_with_cursor_style(&path, state.cursor_style.to_decscusr_code(false)).map(|_| ())
         } else if let Some(doc) = state.documents.active_mut() {
             doc.save(Some(path))
         } else {

--- a/src/bin/edit/draw_menubar.rs
+++ b/src/bin/edit/draw_menubar.rs
@@ -121,6 +121,9 @@ fn draw_menu_view(ctx: &mut Context, state: &mut State) {
             tb.set_word_wrap(!word_wrap);
             ctx.needs_rerender();
         }
+        if ctx.menubar_menu_button("Cursor Style", 'C', vk::NULL) {
+            state.wants_cursor_style_picker = true;
+        }
     }
 
     ctx.menubar_menu_end();

--- a/src/bin/edit/main.rs
+++ b/src/bin/edit/main.rs
@@ -252,20 +252,20 @@ fn handle_args(state: &mut State) -> apperr::Result<bool> {
     }
 
     for p in &paths {
-        state.documents.add_file_path(p)?;
+        state.documents.add_file_path_with_cursor_style(p, state.cursor_style.to_decscusr_code(false))?;
     }
     if let Some(parent) = paths.first().and_then(|p| p.parent()) {
         cwd = parent.to_path_buf();
     }
 
     if let Some(mut file) = sys::open_stdin_if_redirected() {
-        let doc = state.documents.add_untitled()?;
+        let doc = state.documents.add_untitled_with_cursor_style(state.cursor_style.to_decscusr_code(false))?;
         let mut tb = doc.buffer.borrow_mut();
         tb.read_file(&mut file, None)?;
         tb.mark_as_dirty();
     } else if paths.is_empty() {
         // No files were passed, and stdin is not redirected.
-        state.documents.add_untitled()?;
+        state.documents.add_untitled_with_cursor_style(state.cursor_style.to_decscusr_code(false))?;
     }
 
     state.file_picker_pending_dir = DisplayablePathBuf::from_path(cwd);
@@ -316,6 +316,9 @@ fn draw(ctx: &mut Context, state: &mut State) {
     }
     if state.wants_about {
         draw_dialog_about(ctx, state);
+    }
+    if state.wants_cursor_style_picker {
+        draw_cursor_style_picker(ctx, state);
     }
     if ctx.clipboard_ref().wants_host_sync() {
         draw_handle_clipboard_change(ctx, state);

--- a/src/bin/edit/state.rs
+++ b/src/bin/edit/state.rs
@@ -301,7 +301,7 @@ pub fn draw_cursor_style_picker(ctx: &mut Context, state: &mut State) {
     {
         ctx.list_begin("styles");
         ctx.inherit_focus();
-        ctx.attr_padding(Rect::two(1, 1));
+        ctx.attr_padding(Rect::two(1, 2));
         {
             if ctx.list_item(state.cursor_style == CursorStyle::Block, "Block")
                 == ListSelection::Activated
@@ -317,7 +317,7 @@ pub fn draw_cursor_style_picker(ctx: &mut Context, state: &mut State) {
                 state.wants_cursor_style_picker = false;
                 ctx.needs_rerender();
             }
-            if ctx.list_item(state.cursor_style == CursorStyle::IBeam, "I-Beam")
+            if ctx.list_item(state.cursor_style == CursorStyle::IBeam, "Bar")
                 == ListSelection::Activated
             {
                 state.cursor_style = CursorStyle::IBeam;

--- a/src/bin/edit/state.rs
+++ b/src/bin/edit/state.rs
@@ -120,6 +120,29 @@ pub enum StateEncodingChange {
     Reopen,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CursorStyle {
+    Block = 1,     // DECSCUSR 1/2 (block)
+    Underline = 3, // DECSCUSR 3/4 (underline)
+    IBeam = 5,     // DECSCUSR 5/6 (bar)
+}
+
+impl Default for CursorStyle {
+    fn default() -> Self {
+        Self::IBeam
+    }
+}
+
+impl CursorStyle {
+    pub fn to_decscusr_code(self, overtype: bool) -> u8 {
+        match self {
+            CursorStyle::Block => if overtype { 1 } else { 2 },
+            CursorStyle::Underline => if overtype { 3 } else { 4 },
+            CursorStyle::IBeam => if overtype { 5 } else { 6 },
+        }
+    }
+}
+
 pub struct State {
     pub menubar_color_bg: u32,
     pub menubar_color_fg: u32,
@@ -160,6 +183,9 @@ pub struct State {
     pub wants_goto: bool,
     pub goto_target: String,
     pub goto_invalid: bool,
+
+    pub cursor_style: CursorStyle,
+    pub wants_cursor_style_picker: bool,
 
     pub osc_title_filename: String,
     pub osc_clipboard_sync: bool,
@@ -209,6 +235,9 @@ impl State {
             goto_target: Default::default(),
             goto_invalid: false,
 
+            cursor_style: CursorStyle::default(),
+            wants_cursor_style_picker: false,
+
             osc_title_filename: Default::default(),
             osc_clipboard_sync: false,
             osc_clipboard_always_send: false,
@@ -218,7 +247,7 @@ impl State {
 }
 
 pub fn draw_add_untitled_document(ctx: &mut Context, state: &mut State) {
-    if let Err(err) = state.documents.add_untitled() {
+    if let Err(err) = state.documents.add_untitled_with_cursor_style(state.cursor_style.to_decscusr_code(false)) {
         error_log_add(ctx, state, err);
     }
 }
@@ -264,5 +293,41 @@ pub fn draw_error_log(ctx: &mut Context, state: &mut State) {
     }
     if ctx.modal_end() {
         state.error_log_count = 0;
+    }
+}
+
+pub fn draw_cursor_style_picker(ctx: &mut Context, state: &mut State) {
+    ctx.modal_begin("cursor-style", "Cursor Style");
+    {
+        ctx.list_begin("styles");
+        ctx.inherit_focus();
+        ctx.attr_padding(Rect::two(1, 1));
+        {
+            if ctx.list_item(state.cursor_style == CursorStyle::Block, "Block")
+                == ListSelection::Activated
+            {
+                state.cursor_style = CursorStyle::Block;
+                state.wants_cursor_style_picker = false;
+                ctx.needs_rerender();
+            }
+            if ctx.list_item(state.cursor_style == CursorStyle::Underline, "Underline")
+                == ListSelection::Activated
+            {
+                state.cursor_style = CursorStyle::Underline;
+                state.wants_cursor_style_picker = false;
+                ctx.needs_rerender();
+            }
+            if ctx.list_item(state.cursor_style == CursorStyle::IBeam, "I-Beam")
+                == ListSelection::Activated
+            {
+                state.cursor_style = CursorStyle::IBeam;
+                state.wants_cursor_style_picker = false;
+                ctx.needs_rerender();
+            }
+        }
+        ctx.list_end();
+    }
+    if ctx.modal_end() {
+        state.wants_cursor_style_picker = false;
     }
 }

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -207,6 +207,7 @@ pub struct TextBuffer {
     newlines_are_crlf: bool,
     insert_final_newline: bool,
     overtype: bool,
+    cursor_style: u8,
 
     wants_cursor_visibility: bool,
 }
@@ -254,6 +255,7 @@ impl TextBuffer {
             newlines_are_crlf: cfg!(windows), // Windows users want CRLF
             insert_final_newline: false,
             overtype: false,
+            cursor_style: 5, // Default to bar
 
             wants_cursor_visibility: false,
         })
@@ -403,6 +405,16 @@ impl TextBuffer {
     /// Set the overtype mode.
     pub fn set_overtype(&mut self, overtype: bool) {
         self.overtype = overtype;
+    }
+
+    /// Set the cursor style using DECSCUSR codes.
+    pub fn set_cursor_style(&mut self, style: u8) {
+        self.cursor_style = style;
+    }
+
+    /// Get the current cursor style.
+    pub fn cursor_style(&self) -> u8 {
+        self.cursor_style
     }
 
     /// Gets the logical cursor position, that is,
@@ -1516,6 +1528,7 @@ impl TextBuffer {
         origin: Point,
         destination: Rect,
         focused: bool,
+        cursor_style: u8,
         fb: &mut Framebuffer,
     ) -> Option<RenderResult> {
         if destination.is_empty() {
@@ -1804,7 +1817,7 @@ impl TextBuffer {
             };
 
             if text.contains(cursor) {
-                fb.set_cursor(cursor, self.overtype);
+                fb.set_cursor(cursor, self.overtype, cursor_style);
 
                 if self.line_highlight_enabled && selection_beg >= selection_end {
                     fb.blend_bg(

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -396,10 +396,11 @@ impl Framebuffer {
     /// Sets the current visible cursor position and type.
     ///
     /// Call this when focus is inside an editable area and you want to show the cursor.
-    pub fn set_cursor(&mut self, pos: Point, overtype: bool) {
+    pub fn set_cursor(&mut self, pos: Point, overtype: bool, style: u8) {
         let back = &mut self.buffers[self.frame_counter & 1];
         back.cursor.pos = pos;
         back.cursor.overtype = overtype;
+        back.cursor.style = style;
     }
 
     /// Renders the framebuffer contents accumulated since the
@@ -526,7 +527,7 @@ impl Framebuffer {
                     "\x1b[{};{}H\x1b[{} q\x1b[?25h",
                     back.cursor.pos.y + 1,
                     back.cursor.pos.x + 1,
-                    if back.cursor.overtype { 1 } else { 5 }
+                    back.cursor.style
                 );
             } else {
                 // DECTCEM to hide the cursor.
@@ -891,14 +892,15 @@ impl AttributeBuffer {
 struct Cursor {
     pos: Point,
     overtype: bool,
+    style: u8, // DECSCUSR cursor style code
 }
 
 impl Cursor {
     const fn new_invalid() -> Self {
-        Self { pos: Point::MIN, overtype: false }
+        Self { pos: Point::MIN, overtype: false, style: 5 }
     }
 
     const fn new_disabled() -> Self {
-        Self { pos: Point { x: -1, y: -1 }, overtype: false }
+        Self { pos: Point { x: -1, y: -1 }, overtype: false, style: 5 }
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -978,8 +978,9 @@ impl Tui {
                     destination.right -= 1;
                 }
 
+                let cursor_style = tb.cursor_style();
                 if let Some(res) =
-                    tb.render(tc.scroll_offset, destination, tc.has_focus, &mut self.framebuffer)
+                    tb.render(tc.scroll_offset, destination, tc.has_focus, cursor_style, &mut self.framebuffer)
                 {
                     tc.scroll_offset_x_max = res.visual_pos_x_max;
                 }


### PR DESCRIPTION
Closes #452 

This commit introduces a `CursorStyle` enum with different variants corresponding to DECSCUSR codes integrated into the application state.

A new modal dialog, accessible via "View" -> "Cursor Style", allows users to select their preferred cursor style. The rendering pipeline has been updated to consistently support the selected cursor style.

This is a bit of a messy commit so I expect it to be iterated on but I did my best to get an initial implementation with the right behaviour.