### PR TITLE
Fixes #383: Exclude edit.pdb from winget ZIP packages

### DIFF
--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -148,7 +148,6 @@ extends:
                         targetFolder: "$(ob_createvpack_vpackdirectory)/arm64"
                       contents: |
                         *.exe
-                        *.pdb
               # Extract the version for `ob_createvpack_version`.
               - script: |-
                   @echo off
@@ -171,7 +170,7 @@ extends:
                 - pwsh: |-
                     $Dest = New-Item -Type Directory "_staging/${env:RELEASE_NAME}"
                     Write-Host "Staging files from ${env:VPACK_ROOT} at $Dest"
-                    Get-ChildItem "${env:VPACK_ROOT}\*" -Include *.exe, *.pdb | Copy-Item -Destination $Dest -Verbose
+                    Get-ChildItem "${env:VPACK_ROOT}\*" -Include *.exe | Copy-Item -Destination $Dest -Verbose
                     tar.exe -c -v --format=zip -f "$(ob_outputDirectory)\${env:RELEASE_NAME}.zip" -C _staging $env:RELEASE_NAME
                   env:
                     RELEASE_NAME: edit-$(EditVersion)-${{ replace(platform, 'pc-windows-msvc', 'windows') }}


### PR DESCRIPTION
This PR addresses issue #383 by modifying `.pipelines/release.yml` to exclude edit.pdb files from the winget package ZIP (`edit-1.2.0-x86_64-windows.zip` and `edit-1.2.0-aarch64-windows.zip`). The changes ensure that only edit.exe is included, reducing package size as edit.pdb (3MB) is not needed for end users.

Changes:

* Updated the CopyFiles@2 task in release.yml to copy only *.exe files, removing *.pdb.

* Modified the pwsh step in release.yml to include only *.exe files in the ZIP creation.

