### PR TITLE
README.md: Add note for text search needing libicu dev files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Assigning an "edit" alias is recommended if possible.
 
 ## Build Instructions
 
+### ICU development files needed for text search
+As per [this issue](https://github.com/microsoft/edit/issues/172), the system must provide ICU development files for text search. For systems that have separated development packages, please install the ICU development package (i.e. `libicu-devel` for Fedora, `libicu-dev` for Ubuntu, etc.) from your package manager.
+
 * [Install Rust](https://www.rust-lang.org/tools/install)
 * Install the nightly toolchain: `rustup install nightly`
   * Alternatively, set the environment variable `RUSTC_BOOTSTRAP=1`


### PR DESCRIPTION
This PR adds a note about the text search feature requiring `libicu` development libraries, for OSes that have separated dev packages. This includes a link to the relevant [issue](https://github.com/microsoft/edit/issues/172).

Got surprised by this while attempting to package `edit` for Fedora, which is in-progress:
https://bugzilla.redhat.com/show_bug.cgi?id=2372946