### PR TITLE
Auto ignore specific paths in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,19 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+        - '.gitignore'
+        - '.vscode/**'
+        - '**.md'
+        - 'LICENSE'
   pull_request:
     branches:
       - main
+    paths-ignore:
+        - '.gitignore'
+        - '.vscode/**'
+        - '**.md'
+        - 'LICENSE'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Update the CI configuration to ignore certain paths, including `.gitignore`, `.vscode/**`, `**.md`, and `LICENSE`, during push and pull request events.