### PR TITLE
Add CTRL+F3 for quick search using current selection

### DIFF
--- a/src/bin/edit/main.rs
+++ b/src/bin/edit/main.rs
@@ -353,6 +353,8 @@ fn draw(ctx: &mut Context, state: &mut State) {
             state.wants_search.focus = true;
         } else if key == vk::F3 {
             search_execute(ctx, state, SearchAction::Search);
+        } else if key == kbmod::CTRL | vk::F3 {
+            quick_search_execute(ctx, state);
         } else {
             return;
         }


### PR DESCRIPTION
Fix CTRL+F behavior to immediately start searching when text is selected