### PR TITLE
Fix UTF-8 buffer prepending in read_stdin

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -202,8 +202,8 @@ pub fn read_stdin(arena: &Arena, mut timeout: time::Duration) -> Option<ArenaStr
 
         // We got some leftover broken UTF8 from a previous read? Prepend it.
         if STATE.utf8_len != 0 {
-            STATE.utf8_len = 0;
             buf.extend_from_slice(&STATE.utf8_buf[..STATE.utf8_len]);
+            STATE.utf8_len = 0;
         }
 
         loop {


### PR DESCRIPTION
The code zeroed STATE.utf8_len before using it as 
a slice index, which causes leftover UTF-8 bytes from 
previous reads to be discarded instead of prepended to the bu﻿ffer
