### PR TITLE
Indicate unsaved work with U+25CF in the terminal title

### DIFF
--- a/src/bin/edit/main.rs
+++ b/src/bin/edit/main.rs
@@ -168,16 +168,7 @@ fn run() -> apperr::Result<()> {
             let scratch = scratch_arena(None);
             let mut output = tui.render(&scratch);
 
-            {
-                let file_status = state
-                    .documents
-                    .active()
-                    .map(|d| (d.filename.clone(), d.buffer.borrow().is_dirty()));
-                if file_status != state.osc_title_file_status {
-                    write_terminal_title(&mut output, &file_status);
-                    state.osc_title_file_status = file_status;
-                }
-            }
+            write_terminal_title(&mut output, &mut state);
 
             if state.osc_clipboard_sync {
                 write_osc_clipboard(&mut tui, &mut state, &mut output);
@@ -380,19 +371,30 @@ fn draw_handle_wants_exit(_ctx: &mut Context, state: &mut State) {
     }
 }
 
-#[cold]
-fn write_terminal_title(output: &mut ArenaString, file_status: &Option<(String, bool)>) {
-    output.push_str("\x1b]0;");
+fn write_terminal_title(output: &mut ArenaString, state: &mut State) {
+    let (filename, dirty) = state
+        .documents
+        .active()
+        .map_or(("", false), |d| (&d.filename, d.buffer.borrow().is_dirty()));
 
-    if let Some((filename, is_dirty)) = file_status {
-        if *is_dirty {
-            output.push('*');
+    if filename == state.osc_title_file_status.filename
+        && dirty == state.osc_title_file_status.dirty
+    {
+        return;
+    }
+
+    output.push_str("\x1b]0;");
+    if !filename.is_empty() {
+        if dirty {
+            output.push_str("● ");
         }
         output.push_str(&sanitize_control_chars(filename));
         output.push_str(" - ");
     }
-
     output.push_str("edit\x1b\\");
+
+    state.osc_title_file_status.filename = filename.to_string();
+    state.osc_title_file_status.dirty = dirty;
 }
 
 const LARGE_CLIPBOARD_THRESHOLD: usize = 128 * KIBI;

--- a/src/bin/edit/state.rs
+++ b/src/bin/edit/state.rs
@@ -161,7 +161,7 @@ pub struct State {
     pub goto_target: String,
     pub goto_invalid: bool,
 
-    pub osc_title_filename: String,
+    pub osc_title_file_status: Option<(String, bool)>,
     pub osc_clipboard_sync: bool,
     pub osc_clipboard_always_send: bool,
     pub exit: bool,
@@ -209,7 +209,7 @@ impl State {
             goto_target: Default::default(),
             goto_invalid: false,
 
-            osc_title_filename: Default::default(),
+            osc_title_file_status: Default::default(),
             osc_clipboard_sync: false,
             osc_clipboard_always_send: false,
             exit: false,

--- a/src/bin/edit/state.rs
+++ b/src/bin/edit/state.rs
@@ -120,6 +120,12 @@ pub enum StateEncodingChange {
     Reopen,
 }
 
+#[derive(Default)]
+pub struct OscTitleFileStatus {
+    pub filename: String,
+    pub dirty: bool,
+}
+
 pub struct State {
     pub menubar_color_bg: u32,
     pub menubar_color_fg: u32,
@@ -161,7 +167,7 @@ pub struct State {
     pub goto_target: String,
     pub goto_invalid: bool,
 
-    pub osc_title_file_status: Option<(String, bool)>,
+    pub osc_title_file_status: OscTitleFileStatus,
     pub osc_clipboard_sync: bool,
     pub osc_clipboard_always_send: bool,
     pub exit: bool,


### PR DESCRIPTION
Fixes #522

This is a small change that ensures that files that have unsaved changes are shown in the terminal title with an asterisk. It's updated on each change and undo/redo action:

https://github.com/user-attachments/assets/c7f7edc2-2933-4f43-be4d-a14d99dc7f85

