### PR TITLE
Fix #30: Add 256 color support for Terminal.app on macOS

### DIFF
--- a/src/bin/edit/main.rs
+++ b/src/bin/edit/main.rs
@@ -629,6 +629,24 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
         tui.setup_indexed_colors(indexed_colors);
     }
 
+    // Detects if edit is running on an "old" version of terminal.app on Mac OS. If it detects
+    // the terminal.app is older than version 460, which added truecolor support,
+    // is_old_macos_terminal gets set to true, and sets ColorMode to Color256.
+    let is_old_macos_terminal = {
+        if env::var("TERM_PROGRAM").as_deref() == Ok("Apple_Terminal") {
+            env::var("TERM_PROGRAM_VERSION")
+                .ok()
+                .and_then(|s| s.split('.').next()?.parse::<u32>().ok())
+                .map_or(false, |v| v < 460)
+        } else {
+            false
+        }
+    };
+
+    if is_old_macos_terminal {
+        tui.setup_color_mode(framebuffer::ColorMode::Color256);
+    }
+
     RestoreModes
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -154,7 +154,7 @@ use crate::buffer::{CursorMovement, MoveLineDirection, RcTextBuffer, TextBuffer,
 use crate::cell::*;
 use crate::clipboard::Clipboard;
 use crate::document::WriteableDocument;
-use crate::framebuffer::{Attributes, Framebuffer, INDEXED_COLORS_COUNT, IndexedColor, ColorMode};
+use crate::framebuffer::{Attributes, ColorMode, Framebuffer, INDEXED_COLORS_COUNT, IndexedColor};
 use crate::hash::*;
 use crate::helpers::*;
 use crate::input::{InputKeyMod, kbmod, vk};

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -154,7 +154,7 @@ use crate::buffer::{CursorMovement, MoveLineDirection, RcTextBuffer, TextBuffer,
 use crate::cell::*;
 use crate::clipboard::Clipboard;
 use crate::document::WriteableDocument;
-use crate::framebuffer::{Attributes, Framebuffer, INDEXED_COLORS_COUNT, IndexedColor};
+use crate::framebuffer::{Attributes, Framebuffer, INDEXED_COLORS_COUNT, IndexedColor, ColorMode};
 use crate::hash::*;
 use crate::helpers::*;
 use crate::input::{InputKeyMod, kbmod, vk};
@@ -427,6 +427,11 @@ impl Tui {
     /// Sets up the framebuffer's color palette.
     pub fn setup_indexed_colors(&mut self, colors: [u32; INDEXED_COLORS_COUNT]) {
         self.framebuffer.set_indexed_colors(colors);
+    }
+
+    /// Sets the color rendering mode based on terminal capabilities.
+    pub fn setup_color_mode(&mut self, mode: ColorMode) {
+        self.framebuffer.set_color_mode(mode);
     }
 
     /// Set up translations for Ctrl/Alt/Shift modifiers.


### PR DESCRIPTION
Added 256 color support for the current version of apple terminal that doesn't support truecolor. For now, I only added support for terminal.app, since as discussed in https://github.com/microsoft/edit/issues/30, apple's terminal is likely the only modern terminal that doesn't support truecolor. 

I understand apple is adding support for truecolor in MacOS Tahoe, but it will likely be quite some time before most mac users update, and and I'd like to enjoy edit right now without updating to the beta OS. 

Fixes #30 