### PR TITLE
fix: remove trailing carriage return from --version output for cross-platform compatibility

### DIFF
--- a/src/bin/edit/main.rs
+++ b/src/bin/edit/main.rs
@@ -285,7 +285,11 @@ fn print_help() {
 }
 
 fn print_version() {
-    sys::write_stdout(concat!("edit version ", env!("CARGO_PKG_VERSION"), "\r\n"));
+    let version = format!("edit version {}", env!("CARGO_PKG_VERSION"));
+    #[cfg(not(windows))]
+    sys::write_stdout(&format!("{}\n", version));
+    #[cfg(windows)]
+    sys::write_stdout(&format!("{}\r\n", version));
 }
 
 fn draw(ctx: &mut Context, state: &mut State) {


### PR DESCRIPTION
### What this PR does?

This PR updates the `edit --version` output to use platform-specific line endings:

- On Windows: `\r\n` (carriage return + newline)
- On Unix-like systems (Linux, macOS): `\n` only

Previously, the output always used `\r\n`, which introduced a trailing carriage return (`\r`) on Unix platforms. This caused subtle issues in shell scripts, such as incorrect string length and version comparison failures.

#### Before the fix:

```bash
ABC=$(./edit --version) ; echo ${#ABC}
# 19 (includes trailing \r)
```

#### After the fix:
```bash
ABC=$(./edit --version) ; echo ${#ABC}
# 18 (correct length)
```


closes: https://github.com/microsoft/edit/issues/527