### PR TITLE
Chore: Remove unnecessary compile attribute `let_chains`

### DIFF
--- a/src/bin/edit/main.rs
+++ b/src/bin/edit/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![feature(allocator_api, let_chains, linked_list_cursors, string_from_utf8_lossy_owned)]
+#![feature(allocator_api, linked_list_cursors, string_from_utf8_lossy_owned)]
 
 mod documents;
 mod draw_editor;


### PR DESCRIPTION
When compiling with current main head dd61854ad5e795801ca0e4cfff6124812c60c6c6, I get following warnings:

```
warning: the feature `let_chains` has been stable since 1.88.0 and no longer requires an attribute to enable
 --> src\bin\edit\main.rs:4:27
  |
4 | #![feature(allocator_api, let_chains, linked_list_cursors, string_from_utf8_lossy_owned)]
  |                           ^^^^^^^^^^
  |
  = note: `#[warn(stable_features)]` on by default
```

It seems nightly is already enforced, https://github.com/microsoft/edit/blob/dd61854ad5e795801ca0e4cfff6124812c60c6c6/rust-toolchain.toml#L1-L2

We can safely remove this as the current nightly version > $1.88.0$ : 
```
PS D:\edit> rustc --version
rustc 1.90.0-nightly (5adb489a8 2025-07-05)
```