### PR TITLE
Allow selection to persist while scrolling with the mousewheel

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -232,6 +232,9 @@ pub enum InputMouseState {
 
     // These 2 get reset to None on the next frame.
     Release,
+    // Compared to the other mouse-buttons, vt::Token::Csi does not receive
+    // an up event for ::Scroll, so is unable to send a ::None value.
+    // That is why it never triggers a ::Release itself and needs to be reset as well.
     Scroll,
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -574,12 +574,17 @@ impl Tui {
                     && next_state != InputMouseState::None;
                 let mouse_up = self.mouse_state != InputMouseState::None
                     && next_state == InputMouseState::None;
-                let is_drag = self.mouse_state == InputMouseState::Left
-                    && next_state == InputMouseState::Left;
-                let is_scroll_drag = self.mouse_state == InputMouseState::Left
-                    && next_state == InputMouseState::Scroll;
 
-                self.mouse_is_drag = is_drag || is_scroll_drag;
+                // At the time of writing this, ::Release should not happen here.
+                // But it would break functionality, so we should check for it.
+                let all_buttons_released =
+                    next_state == InputMouseState::None || next_state == InputMouseState::Release;
+
+                // As long as the last state was ::Left, and the next event is neither ::None nor ::Release,
+                // we could not have possibly let go of the button yet, so we must be either long-clicking or dragging.
+                // In our case both scenarios may start a drag.
+                self.mouse_is_drag =
+                    self.mouse_state == InputMouseState::Left && !all_buttons_released;
 
                 let mut hovered_node = None; // Needed for `mouse_down`
                 let mut focused_node = None; // Needed for `mouse_down` and `is_click`

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -510,21 +510,15 @@ impl Tui {
         // Now, a frame later, we must reset it back to none, to stop it from triggering things.
         // Same for Scroll events, unless there is an active drag happening.
         if self.mouse_state > InputMouseState::Right {
-            let is_scroll_event = self.mouse_state == InputMouseState::Scroll;
-            let selection_in_progress = self.left_mouse_down_target != 0 && self.mouse_is_drag;
-
-            // If we are both, actively receiving a scroll event and a selection is in progress at the same time,
-            // that means we are currently scrolling the screen while actively drag-selecting.
-            // This means we are just receiving the Release event of the scroll wheel,
-            // so we need to preserve the current drag instead of resetting it.
-            if is_scroll_event && selection_in_progress {
+            if self.mouse_is_drag {
+                // Maintain drag state
                 self.mouse_state = InputMouseState::Left;
             } else {
+                // Reset the drag operation
                 self.mouse_down_position = Point::MIN;
                 self.mouse_down_node_path.clear();
                 self.left_mouse_down_target = 0;
                 self.mouse_state = InputMouseState::None;
-                self.mouse_is_drag = false;
             }
         }
 
@@ -581,8 +575,11 @@ impl Tui {
                 let mouse_up = self.mouse_state != InputMouseState::None
                     && next_state == InputMouseState::None;
                 let is_drag = self.mouse_state == InputMouseState::Left
-                    && next_state == InputMouseState::Left
-                    && next_position != self.mouse_position;
+                    && next_state == InputMouseState::Left;
+                let is_scroll_drag = self.mouse_state == InputMouseState::Left
+                    && next_state == InputMouseState::Scroll;
+
+                self.mouse_is_drag = is_drag || is_scroll_drag;
 
                 let mut hovered_node = None; // Needed for `mouse_down`
                 let mut focused_node = None; // Needed for `mouse_down` and `is_click`
@@ -673,8 +670,6 @@ impl Tui {
                     }
 
                     self.mouse_up_timestamp = now;
-                } else if is_drag {
-                    self.mouse_is_drag = true;
                 }
 
                 input_mouse_modifiers = mouse.modifiers;


### PR DESCRIPTION
Hello,

This PR addresses the issue where the text-selection/drag-operation would be interrupted and restart when scrolling the document using the mousewheel.

Resolves #410

[TLDR ➚](https://github.com/microsoft/edit/pull/588/files) 

Reading the diffs should hopefully provide enough context.

<details>
  <summary>Otherwise: How we got here (but outdated as of last commit)</summary>

### Summary
I included the first commit in the PR for context, showing the initial approach before refocusing on a cleaner solution. I felt reasonably safe about the app state, since it just handled this one edge case right before it goes wrong.   [(➚)](https://github.com/microsoft/edit/commit/9b80222f5e5bd93abddad102f657c95d61995af3#diff-99d530b2e5fd9f864743e736b71f188565c40f7881736572bccd3d91e8c6bd30R520)
But also noticed that it was still not possible to start a selection by:
Left->Scroll while holding the mouse still.

I decided it would be better solved by moving closer to the source of the problem instead.
While it seems a bit harder to reason about the change now, I feel like this is the cleaner solution.

### What changed
- mouse_is_drag no longer requires mouse movement.   [(➚)](https://github.com/microsoft/edit/commit/c74fe4073ffcaab6a901bff68e5aa20ce8d17e7f#diff-99d530b2e5fd9f864743e736b71f188565c40f7881736572bccd3d91e8c6bd30L585)
  If two successive frames have ::Left, it should be safe to assume it is a drag operation even without movement?

- Maintain drag state while being interrupted by a scroll by passing ::Left to the next state.   [(➚)](https://github.com/microsoft/edit/commit/9b80222f5e5bd93abddad102f657c95d61995af3#diff-99d530b2e5fd9f864743e736b71f188565c40f7881736572bccd3d91e8c6bd30R521)
  Drag can only be initialized by ::Left, so this should be safe?

- mouse_up/mouse_down are now more clearly decoupled from mouse_is_drag state [(➚)](https://github.com/microsoft/edit/commit/0735e4a6c01d5b97ae4accbe3b1d65a377d2ea08#diff-99d530b2e5fd9f864743e736b71f188565c40f7881736572bccd3d91e8c6bd30L677)
   - Initially introduced a separate value to track is_scroll_drag state. [(2nd commit ➚)](https://github.com/microsoft/edit/commit/0735e4a6c01d5b97ae4accbe3b1d65a377d2ea08#diff-99d530b2e5fd9f864743e736b71f188565c40f7881736572bccd3d91e8c6bd30R573)
   - But in the end it turned into covering all the cases of is_drag so we could get away with less. [(3rd commit ➚)](https://github.com/microsoft/edit/commit/460acb986dc9d39a8ec9f252d7f26429548ad608#diff-99d530b2e5fd9f864743e736b71f188565c40f7881736572bccd3d91e8c6bd30R587)
  
### Manual testing
<details>
  <summary>Click to expand.</summary>

- [x] Tested using scroll-wheel:
![edit_select_scroll](https://github.com/user-attachments/assets/3daa8030-49d5-4bc1-91f6-25c99da18bbd)

- [x] Using edge scrolling:
![edit_select_edge_pan](https://github.com/user-attachments/assets/e3549ad8-4657-42a9-b0ef-023fcd1bf84d)

- [x] Open File list scroll and click navigation appear to also still be working as intended.

#### State Flow Exploration
Below some state flow logs of the most common cases. Shows how current/next states relate.
And that is_drag was a logical subset of is_scroll_drag, at least in these scenarios.
<details>
  <summary>Click to expand.</summary>

``` d
## State-flow:
### Just 1 click into the editor.
Curr:None    is_drag:false    is_scroll_drag:false
Next:Left    is_drag:false    is_scroll_drag:false
MouseDown!
Curr:Left    is_drag:false    is_scroll_drag:false
Next:None    is_drag:false    is_scroll_drag:false
MouseUp!
Resetting Drag!

### Simple click-drag-select
Curr:None    is_drag:false    is_scroll_drag:false
Next:Left    is_drag:false    is_scroll_drag:false
MouseDown!
Curr:Left    is_drag:true     is_scroll_drag:true
Next:Left    is_drag:true     is_scroll_drag:true
Curr:Left    is_drag:true     is_scroll_drag:true
Next:Left    is_drag:true     is_scroll_drag:true
Curr:Left    is_drag:false    is_scroll_drag:false
Next:None    is_drag:false    is_scroll_drag:false
MouseUp!
Resetting Drag

### Click + Scroll, no drag (Mouse still)
Will not draw selection right away, but does not break it either.
Same behavior as VSCode/IntelliJ.

Curr:None    is_drag:false    is_scroll_drag:false
Next:Left    is_drag:false    is_scroll_drag:false
MouseDown!
Curr:Left    is_drag:false    is_scroll_drag:true
Next:Scroll  is_drag:false    is_scroll_drag:true
Maintaining drag.
Curr:Left    is_drag:false    is_scroll_drag:false
Next:None    is_drag:false    is_scroll_drag:false
MouseUp!
Resetting Drag

### Scrolling while dragging. 
Curr:None      is_drag:false    is_scroll_drag:false
Next:Left      is_drag:false    is_scroll_drag:false
MouseDown!  
Curr:Left      is_drag:true     is_scroll_drag:true
Next:Left      is_drag:true     is_scroll_drag:true
Curr:Left      is_drag:true     is_scroll_drag:true
Next:Left      is_drag:true     is_scroll_drag:true
Curr:Left      is_drag:false    is_scroll_drag:true
Next:Scroll    is_drag:false    is_scroll_drag:true
Maintaining drag.
Curr:Left      is_drag:true     is_scroll_drag:true
Next:Left      is_drag:true     is_scroll_drag:true
...  
Curr:Left      is_drag:true     is_scroll_drag:true
Next:Left      is_drag:true     is_scroll_drag:true
Curr:Left      is_drag:false    is_scroll_drag:true
Next:Scroll    is_drag:false    is_scroll_drag:true
Maintaining drag.
Curr:Left      is_drag:true     is_scroll_drag:true
Next:Left      is_drag:true     is_scroll_drag:true
...  
Curr:Left      is_drag:true     is_scroll_drag:true
Next:Left      is_drag:true     is_scroll_drag:true
Curr:Left      is_drag:false    is_scroll_drag:true
Next:Scroll    is_drag:false    is_scroll_drag:true
Maintaining drag.
Curr:Left      is_drag:true     is_scroll_drag:true
Next:Left      is_drag:true     is_scroll_drag:true
Curr:Left      is_drag:false    is_scroll_drag:true
Next:Scroll    is_drag:false    is_scroll_drag:true
Maintaining drag.
Curr:Left      is_drag:true     is_scroll_drag:true
Next:Left      is_drag:true     is_scroll_drag:true
...
Curr:Left      is_drag:true     is_scroll_drag:true
Next:Left      is_drag:true     is_scroll_drag:true
Curr:Left      is_drag:false    is_scroll_drag:false
Next:None      is_drag:false    is_scroll_drag:false
MouseUp!
Resetting Drag
```
</details>
</details>


---

</details>


#### Possible future enhancements

- Scrolling will not update the selection right away without moving the mouse first.
- Other buttons (::Right, ::Middle) still interrupt/restart the selection.

---

While relatively small, I think this PR already offers plenty of edge cases to think about.
Additional enhancements are probably best handled in separate PRs.

Thanks! Feedback welcome~