### PR TITLE
Replace vseq/vand with their immediate-form variants

### DIFF
--- a/src/simd/lines_bwd.rs
+++ b/src/simd/lines_bwd.rs
@@ -280,7 +280,7 @@ unsafe fn lines_bwd_lsx(
             }
         }
 
-        let lf = lsx_vrepli_b(b'\n' as i32);
+        const LF: i32 = b'\n' as i32;
         let line_stop = line_stop.min(line);
         let off = end.addr() & 15;
         if off != 0 && off < end.offset_from_unsigned(beg) {
@@ -295,11 +295,11 @@ unsafe fn lines_bwd_lsx(
             let v3 = lsx_vld::<32>(chunk_start as *const _);
             let v4 = lsx_vld::<48>(chunk_start as *const _);
 
-            let mut sum = lsx_vrepli_b(0);
-            sum = lsx_vsub_b(sum, lsx_vseq_b(v1, lf));
-            sum = lsx_vsub_b(sum, lsx_vseq_b(v2, lf));
-            sum = lsx_vsub_b(sum, lsx_vseq_b(v3, lf));
-            sum = lsx_vsub_b(sum, lsx_vseq_b(v4, lf));
+            let mut sum = lsx_vldi::<0>();
+            sum = lsx_vsub_b(sum, lsx_vseqi_b::<LF>(v1));
+            sum = lsx_vsub_b(sum, lsx_vseqi_b::<LF>(v2));
+            sum = lsx_vsub_b(sum, lsx_vseqi_b::<LF>(v3));
+            sum = lsx_vsub_b(sum, lsx_vseqi_b::<LF>(v4));
             let sum = horizontal_sum(sum);
 
             let line_next = line - sum as CoordType;
@@ -314,9 +314,9 @@ unsafe fn lines_bwd_lsx(
         while end.offset_from_unsigned(beg) >= 16 {
             let chunk_start = end.sub(16);
             let v = lsx_vld::<0>(chunk_start as *const _);
-            let c = lsx_vseq_b(v, lf);
+            let c = lsx_vseqi_b::<LF>(v);
 
-            let ones = lsx_vand_v(c, lsx_vrepli_b(1));
+            let ones = lsx_vandi_b::<1>(c);
             let sum = horizontal_sum(ones);
 
             let line_next = line - sum as CoordType;

--- a/src/simd/lines_fwd.rs
+++ b/src/simd/lines_fwd.rs
@@ -285,7 +285,7 @@ unsafe fn lines_fwd_lsx(
             }
         }
 
-        let lf = lsx_vrepli_b(b'\n' as i32);
+        const LF: i32 = b'\n' as i32;
         let off = beg.align_offset(16);
         if off != 0 && off < end.offset_from_unsigned(beg) {
             (beg, line) = lines_fwd_fallback(beg, beg.add(off), line, line_stop);
@@ -298,11 +298,11 @@ unsafe fn lines_fwd_lsx(
                 let v3 = lsx_vld::<32>(beg as *const _);
                 let v4 = lsx_vld::<48>(beg as *const _);
 
-                let mut sum = lsx_vrepli_b(0);
-                sum = lsx_vsub_b(sum, lsx_vseq_b(v1, lf));
-                sum = lsx_vsub_b(sum, lsx_vseq_b(v2, lf));
-                sum = lsx_vsub_b(sum, lsx_vseq_b(v3, lf));
-                sum = lsx_vsub_b(sum, lsx_vseq_b(v4, lf));
+                let mut sum = lsx_vldi(0);
+                sum = lsx_vsub_b(sum, lsx_vseqi_b::<LF>(v1));
+                sum = lsx_vsub_b(sum, lsx_vseqi_b::<LF>(v2));
+                sum = lsx_vsub_b(sum, lsx_vseqi_b::<LF>(v3));
+                sum = lsx_vsub_b(sum, lsx_vseqi_b::<LF>(v4));
                 let sum = horizontal_sum(sum);
 
                 let line_next = line + sum as CoordType;
@@ -316,9 +316,9 @@ unsafe fn lines_fwd_lsx(
 
             while end.offset_from_unsigned(beg) >= 16 {
                 let v = lsx_vld::<0>(beg as *const _);
-                let c = lsx_vseq_b(v, lf);
+                let c = lsx_vseqi_b::<LF>(v);
 
-                let ones = lsx_vand_v(c, lsx_vrepli_b(1));
+                let ones = lsx_vandi_b::<1>(c);
                 let sum = horizontal_sum(ones);
 
                 let line_next = line + sum as CoordType;


### PR DESCRIPTION
```
simd/lines_fwd/134217728
                        time:   [4.3447 ms 4.3474 ms 4.3505 ms]
                        thrpt:  [28.732 GiB/s 28.753 GiB/s 28.771 GiB/s]
                 change:
                        time:   [−1.8221% −1.7185% −1.6176%] (p = 0.00 < 0.05)
                        thrpt:  [+1.6442% +1.7485% +1.8559%]
                        Performance has improved.
```