### PR TITLE
sys/win: display a useful error message when SetConsoleMode fails

### DIFF
--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -174,7 +174,7 @@ pub fn switch_modes() -> apperr::Result<()> {
                 | Console::ENABLE_VIRTUAL_TERMINAL_INPUT,
         )) {
             Err(e) if e == gle_to_apperr(ERROR_INVALID_PARAMETER) => {
-                Err(gle_to_apperr(ERROR_UNSUPPORTED_LEGACY_CONSOLE))
+                Err(apperr::Error::Sys(ERROR_UNSUPPORTED_LEGACY_CONSOLE))
             }
             other => other,
         }?;


### PR DESCRIPTION
edit will now display specific error messages when the console fails to support `ENABLE_VIRTUAL_TERMINAL_INPUT`. On Windows 8.1, the user will be gently reprimanded to update to Windows 10. On Windows 10, they will be coerced into using the modern console host.

We only check the version after this fails because it is technically possible to run edit on OpenConsole (or another third-party console host!)--even on Windows 8.1--where it will work properly.