### PR TITLE
Update Cargo.toml and release configuration for panic strategy changes

### DIFF
--- a/.cargo/release-windows-ms.toml
+++ b/.cargo/release-windows-ms.toml
@@ -16,7 +16,7 @@ rustflags = [
 # = Huge reduction in binary size by removing all that.
 [unstable]
 build-std = ["std", "panic_abort"]
-build-std-features = ["panic_immediate_abort", "optimize_for_size"]
+build-std-features = ["optimize_for_size"]
 
 # vvv The following parts are specific to official Windows builds. vvv
 # (The use of internal registries, security features, etc., are mandatory.)

--- a/.cargo/release.toml
+++ b/.cargo/release.toml
@@ -20,4 +20,4 @@ rustflags = [
 # = Huge reduction in binary size by removing all that.
 [unstable]
 build-std = ["std", "panic_abort"]
-build-std-features = ["default", "panic_immediate_abort", "optimize_for_size"]
+build-std-features = ["default", "optimize_for_size"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["panic-immediate-abort"]
+
 [package]
 name = "edit"
 version = "1.2.1"
@@ -25,7 +27,7 @@ codegen-units = 1           # reduces binary size by ~2%
 debug = "full"              # No one needs an undebuggable release binary
 lto = true                  # reduces binary size by ~14%
 opt-level = "s"             # reduces binary size by ~25%
-panic = "abort"             # reduces binary size by ~50% in combination with -Zbuild-std-features=panic_immediate_abort
+panic = "immediate-abort"   # reduces binary size by ~50% (panic_immediate_abort is now a real panic strategy)
 split-debuginfo = "packed"  # generates a separate *.dwp/*.dSYM so the binary can get stripped
 strip = "symbols"           # See split-debuginfo - allows us to drop the size by ~65%
 incremental = true          # Improves re-compile times


### PR DESCRIPTION
- Changed panic strategy from "abort" to "immediate-abort" in Cargo.toml to reflect the new panic handling approach.
- Removed "panic_immediate_abort" from build-std-features in release configuration files to streamline the build process and reduce binary size.

this resolves #657 