### PR TITLE
Fix Rust nightly builds

### DIFF
--- a/.cargo/release-nightly.toml
+++ b/.cargo/release-nightly.toml
@@ -1,0 +1,16 @@
+[profile.release]
+panic = "immediate-abort"
+
+[target.'cfg(all(target_os = "windows", target_env = "msvc"))']
+rustflags = [
+    "-Ctarget-feature=+crt-static",
+    "-Clink-args=/DEFAULTLIB:ucrt.lib",
+    "-Clink-args=/NODEFAULTLIB:vcruntime.lib",
+    "-Clink-args=/NODEFAULTLIB:msvcrt.lib",
+    "-Clink-args=/NODEFAULTLIB:libucrt.lib",
+]
+
+[unstable]
+panic-immediate-abort = true
+build-std = ["std", "panic_abort"]
+build-std-features = ["default", "optimize_for_size"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ winget install Microsoft.Edit
 * Install the nightly toolchain: `rustup install nightly`
   * Alternatively, set the environment variable `RUSTC_BOOTSTRAP=1`
 * Clone the repository
-* For a release build, run: `cargo build --config .cargo/release.toml --release`
+* For a release build, run:
+  * Rust 1.90 or earlier: `cargo build --config .cargo/release.toml --release`
+  * otherwise: `cargo build --config .cargo/release-nightly.toml --release`
 
 ### Build Configuration
 


### PR DESCRIPTION
`panic_immediate_abort` is being stablized as `panic = immediate-abort` (yay!).
See: https://github.com/rust-lang/rust/issues/147286

Closes #657