### PR TITLE
Add Portuguese (pt-PT) translations

### DIFF
--- a/i18n/edit.toml
+++ b/i18n/edit.toml
@@ -8,7 +8,6 @@ __default__ = [
     "ja",
     "ko",
     "pt_br",
-    "pt_pt",
     "ru",
     "zh_hans",
     "zh_hant",
@@ -16,8 +15,6 @@ __default__ = [
 
 [__alias__]
 zh = "zh_hans"
-"pt-pt" = "pt_pt"
-"pt-br" = "pt_br"
 
 # The keyboard key
 [Ctrl]


### PR DESCRIPTION
Added pt-PT to __default__, aliases for "pt-pt" and "pt-br", translations for common UI strings. Why? Support European Portuguese users (Portugal).