### PR TITLE
Fix colors with Terminal.app's Clear Dark theme

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch Debug (Windows)",
+            "name": "Launch edit (Windows)",
             "preLaunchTask": "rust: cargo build",
             "type": "cppvsdbg",
             "request": "launch",
@@ -14,7 +14,7 @@
             ],
         },
         {
-            "name": "Launch Debug (GDB)",
+            "name": "Launch edit (GDB, Linux)",
             "preLaunchTask": "rust: cargo build",
             "type": "cppdbg",
             "request": "launch",
@@ -27,15 +27,28 @@
             ],
         },
         {
-            "name": "Launch Debug (LLDB)",
+            // NOTE for macOS: In order for this task to work you have to:
+            // 1. Run the "Fix externalConsole on macOS" task once
+            // 2. Add the following to your VS Code settings:
+            //    "lldb-dap.environment": {
+            //        "LLDB_LAUNCH_FLAG_LAUNCH_IN_TTY": "YES"
+            //    }
+            "name": "Launch edit (lldb-dap, macOS)",
             "preLaunchTask": "rust: cargo build",
-            "type": "lldb",
+            "type": "lldb-dap",
             "request": "launch",
             "program": "${workspaceFolder}/target/debug/edit",
             "cwd": "${workspaceFolder}",
             "args": [
                 "${workspaceFolder}/crates/edit/src/bin/edit/main.rs"
             ],
-        }
+        },
+        {
+            // This is a workaround for https://github.com/microsoft/vscode-cpptools/issues/5079
+            "name": "Fix externalConsole on macOS",
+            "type": "node-terminal",
+            "request": "launch",
+            "command": "osascript -e 'tell application \"Terminal\"\ndo script \"echo hello\"\nend tell'"
+        },
     ]
 }

--- a/crates/edit/Cargo.toml
+++ b/crates/edit/Cargo.toml
@@ -15,6 +15,7 @@ name = "lib"
 harness = false
 
 [features]
+# Display editor latency in the top-right corner
 debug-latency = []
 
 [dependencies]

--- a/crates/edit/src/bin/edit/main.rs
+++ b/crates/edit/src/bin/edit/main.rs
@@ -12,8 +12,6 @@ mod localization;
 mod state;
 
 use std::borrow::Cow;
-#[cfg(feature = "debug-latency")]
-use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::{env, process};
@@ -23,7 +21,7 @@ use draw_filepicker::*;
 use draw_menubar::*;
 use draw_statusbar::*;
 use edit::framebuffer::{self, IndexedColor};
-use edit::helpers::{CoordType, KIBI, MEBI, MetricFormatter, Rect, Size};
+use edit::helpers::*;
 use edit::input::{self, kbmod, vk};
 use edit::oklab::StraightRgba;
 use edit::tui::*;
@@ -178,6 +176,8 @@ fn run() -> apperr::Result<()> {
 
             #[cfg(feature = "debug-latency")]
             {
+                use std::fmt::Write as _;
+
                 // Print the number of passes and latency in the top right corner.
                 let time_end = std::time::Instant::now();
                 let status = time_end - time_beg;

--- a/crates/edit/src/helpers.rs
+++ b/crates/edit/src/helpers.rs
@@ -82,6 +82,9 @@ pub struct Size {
 }
 
 impl Size {
+    pub const MIN: Self = Self { width: 0, height: 0 };
+    pub const MAX: Self = Self { width: CoordType::MAX, height: CoordType::MAX };
+
     pub fn as_rect(&self) -> Rect {
         Rect { left: 0, top: 0, right: self.width, bottom: self.height }
     }

--- a/crates/edit/src/sys/unix.rs
+++ b/crates/edit/src/sys/unix.rs
@@ -11,7 +11,7 @@ use std::fs::File;
 use std::mem::{self, ManuallyDrop, MaybeUninit};
 use std::os::fd::{AsRawFd as _, FromRawFd as _};
 use std::path::Path;
-use std::ptr::{self, NonNull, null_mut};
+use std::ptr::{NonNull, null_mut};
 use std::{thread, time};
 
 use stdext::arena::{Arena, ArenaString, scratch_arena};
@@ -203,7 +203,7 @@ pub fn read_stdin(arena: &Arena, mut timeout: time::Duration) -> Option<ArenaStr
                         tv_sec: timeout.as_secs() as libc::time_t,
                         tv_nsec: timeout.subsec_nanos() as libc::c_long,
                     };
-                    ret = libc::ppoll(&mut pollfd, 1, &ts, ptr::null());
+                    ret = libc::ppoll(&mut pollfd, 1, &ts, std::ptr::null());
                 }
                 #[cfg(not(target_os = "linux"))]
                 {

--- a/crates/stdext/src/arena/string.rs
+++ b/crates/stdext/src/arena/string.rs
@@ -95,6 +95,13 @@ impl<'a> ArenaString<'a> {
         }
     }
 
+    #[must_use]
+    pub fn from_iter<T: IntoIterator<Item = char>>(arena: &'a Arena, iter: T) -> Self {
+        let mut s = Self::new_in(arena);
+        s.extend(iter);
+        s
+    }
+
     /// It's empty.
     pub fn is_empty(&self) -> bool {
         self.vec.is_empty()
@@ -282,6 +289,18 @@ impl fmt::Write for ArenaString<'_> {
         self.push(c);
         Ok(())
     }
+}
+
+impl Extend<char> for ArenaString<'_> {
+    fn extend<I: IntoIterator<Item = char>>(&mut self, iter: I) {
+        let iterator = iter.into_iter();
+        let (lower_bound, _) = iterator.size_hint();
+        self.reserve(lower_bound);
+        iterator.for_each(move |c| self.push(c));
+    }
+
+    // TODO: This is where I'd put `extend_one` and `extend_reserve` impls, *but as always*,
+    // essential stdlib functions are unstable and that means we can't have them.
 }
 
 #[macro_export]


### PR DESCRIPTION
This fixes the menubar colors with macOS 26's new terminal theme,
Clear Dark. The changeset also contains improvements to the
debug tasks, and a few new helpers that I'll need later.