### PR TITLE
clippy: fix unused_imports lint

### DIFF
--- a/crates/edit/src/sys/unix.rs
+++ b/crates/edit/src/sys/unix.rs
@@ -11,7 +11,7 @@ use std::fs::File;
 use std::mem::{self, ManuallyDrop, MaybeUninit};
 use std::os::fd::{AsRawFd as _, FromRawFd as _};
 use std::path::Path;
-use std::ptr::{self, NonNull, null_mut};
+use std::ptr::{NonNull, null_mut};
 use std::{thread, time};
 
 use stdext::arena::{Arena, ArenaString, scratch_arena};


### PR DESCRIPTION
fixes failure with:
```sh
cargo clippy --all-features --all-targets -- --no-deps --deny warnings
```