### PR TITLE
Use platform line ending when opening single line files

### DIFF
--- a/crates/edit/src/buffer/mod.rs
+++ b/crates/edit/src/buffer/mod.rs
@@ -769,8 +769,8 @@ impl TextBuffer {
                 }
             }
 
-            // We'll assume CRLF if more than half of the lines end in CRLF.
-            let newlines_are_crlf = crlf_count >= lines / 2;
+            // We'll assume CRLF if more than half of the lines end in CRLF. If there is only a single line, we'll use the platform default.
+            let newlines_are_crlf = if lines == 0 { cfg!(windows) } else { crlf_count > lines / 2 };
 
             // We'll assume tabs if there are more lines starting with tabs than with spaces.
             let indent_with_tabs = tab_indentations > space_indentations;


### PR DESCRIPTION
Currently when opening a file with only one line the heuristic for line ending always assumes CRLF. This pr instead uses the default line ending for the platform to be consistent with creating new files.

This is a new pull request with the same change as https://github.com/microsoft/edit/pull/723 since I messed up that one when trying to rebase it.