### PR TITLE
Add Bash, Zsh, Python and JavaScript highlighting

### DIFF
--- a/assets/highlighting-tests/javascript.js
+++ b/assets/highlighting-tests/javascript.js
@@ -1,0 +1,59 @@
+// Single-line comment
+/* Multi-line
+   comment */
+
+const single = 'single quoted string';
+const double = "double quoted string";
+const template = `template string with ${single}`;
+
+const decimal = 42;
+const negative = -3.14e+2;
+const hex = 0x2a;
+const binary = 0b101010;
+const octal = 0o52;
+
+const truthy = true;
+const falsy = false;
+const empty = null;
+const missing = undefined;
+const notANumber = NaN;
+const infinite = Infinity;
+
+export async function greet(name) {
+  if (name instanceof String) {
+    return;
+  } else if (name in { user: "ok" }) {
+    throw new Error("unexpected");
+  }
+
+  for (let i = 0; i < 3; i++) {
+    while (false) {
+      break;
+    }
+  }
+
+  try {
+    return console.log(template, name);
+  } catch (error) {
+    return void error;
+  } finally {
+    delete globalThis.temp;
+  }
+}
+
+class Person extends Object {
+  constructor(name) {
+    super();
+    this.name = name;
+  }
+}
+
+const result = greet("world");
+switch (result) {
+  case true:
+    break;
+  default:
+    continueLabel: do {
+      break continueLabel;
+    } while (false);
+}

--- a/assets/highlighting-tests/markdown.md
+++ b/assets/highlighting-tests/markdown.md
@@ -66,10 +66,21 @@ Reference: ![Logo][logo-ref]
 echo "Hello, world" | tr a-z A-Z
 ```
 
+```javascript
+export function greet(name) {
+  return `hello ${name}`;
+}
+```
+
 ```json
 {
   "name": "gfm-kitchen-sink",
   "private": true,
   "scripts": { "test": "echo ok" }
 }
+```
+
+```python
+def greet(name: str) -> str:
+    return f"hello {name}"
 ```

--- a/assets/highlighting-tests/python.py
+++ b/assets/highlighting-tests/python.py
@@ -1,0 +1,48 @@
+# Single-line comment
+'''Triple single quoted string'''
+"""Triple double quoted string"""
+
+single = 'single quoted string'
+double = "double quoted string"
+
+decimal = 42
+negative = -3.14e+2
+hex_value = 0x2A
+binary_value = 0b101010
+octal_value = 0o52
+complex_value = 1.5j
+
+truthy = True
+falsy = False
+nothing = None
+
+@decorator
+async def greet(name: str) -> None:
+    value = f"Hello, {name}"
+
+    if value and name is not None:
+        print(value)
+    elif value in {"hello", "world"}:
+        raise ValueError("unexpected")
+    else:
+        return None
+
+    for item in [single, double]:
+        while False:
+            break
+
+    try:
+        assert item
+    except Exception as exc:
+        yield exc
+    finally:
+        pass
+
+
+class Person:
+    def __init__(self, name):
+        self.name = name
+
+
+result = greet("world")
+lambda_value = lambda x: x + 1

--- a/assets/highlighting-tests/zsh.sh
+++ b/assets/highlighting-tests/zsh.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env zsh
+# zsh-style shell sample
+
+setopt autocd extendedglob
+
+typeset -g POWERLEVEL="lean"
+readonly ZSH_THEME="agnoster"
+
+plugins=(git docker fzf)
+
+alias ll='ls -lah'
+alias gs='git status'
+
+path=("$HOME/bin" $path)
+export EDITOR="nvim"
+
+function mkcd() {
+    local dir="$1"
+    mkdir -p "$dir" && cd "$dir"
+}
+
+if [[ -n "$HOME" ]]; then
+    echo "home is $HOME"
+elif [[ -z "$HOME" ]]; then
+    echo "missing home"
+else
+    echo "unexpected"
+fi
+
+for plugin in $plugins; do
+    echo "$plugin"
+done
+
+case "$ZSH_THEME" in
+    agnoster) echo "theme selected" ;;
+    *) echo "default theme" ;;
+esac
+
+source "$HOME/.zsh_aliases"
+mkcd "${HOME}/tmp"

--- a/crates/lsh/definitions/bash.lsh
+++ b/crates/lsh/definitions/bash.lsh
@@ -1,0 +1,61 @@
+#[display_name = "Bash"]
+#[path = "**/*.bash"]
+#[path = "**/*.sh"]
+#[path = "**/.bash_profile"]
+#[path = "**/.bashrc"]
+#[path = "**/.profile"]
+pub fn bash() {
+    until /$/ {
+        yield other;
+
+        if /#.*/ {
+            yield comment;
+        } else if /'/ {
+            until /$/ {
+                yield string;
+                if /'/ { yield string; break; }
+                await input;
+            }
+        } else if /"/ {
+            until /$/ {
+                yield string;
+                if /\\./ {}
+                else if /"/ { yield string; break; }
+                await input;
+            }
+        } else if /`/ {
+            until /$/ {
+                yield string;
+                if /\\./ {}
+                else if /`/ { yield string; break; }
+                await input;
+            }
+        } else if /\$\{[^}]+\}|\$[A-Za-z_]\w*|\$\d+|\$[#?*!@$-]/ {
+            yield variable;
+        } else if /(?:if|then|elif|else|fi|for|while|until|do|done|case|esac|in|select)\>/ {
+            if /\w+/ {
+                yield other;
+            } else {
+                yield keyword.control;
+            }
+        } else if /(?:declare|export|function|local|readonly|source)\>/ {
+            if /\w+/ {
+                yield other;
+            } else {
+                yield keyword.other;
+            }
+        } else if /-?(?:0[xX][\da-fA-F]+|\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/ {
+            if /\w+/ {
+                yield other;
+            } else {
+                yield constant.numeric;
+            }
+        } else if /([A-Za-z_][\w-]*)\s*\(/ {
+            yield $1 as method;
+        } else if /[A-Za-z_][\w-]*/ {
+            // Gobble any other tokens that should not be highlighted
+        }
+
+        yield other;
+    }
+}

--- a/crates/lsh/definitions/bash.lsh
+++ b/crates/lsh/definitions/bash.lsh
@@ -44,7 +44,7 @@ pub fn bash() {
             } else {
                 yield keyword.other;
             }
-        } else if /-?(?:0[xX][\da-fA-F]+|\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/ {
+        } else if /-?(?:(?i:0x[\da-fA-F]+)|\d+\.?\d*|\.\d+)(?i:e[+-]?\d+)?/ {
             if /\w+/ {
                 yield other;
             } else {

--- a/crates/lsh/definitions/javascript.lsh
+++ b/crates/lsh/definitions/javascript.lsh
@@ -1,0 +1,74 @@
+#[display_name = "JavaScript"]
+#[path = "**/*.cjs"]
+#[path = "**/*.js"]
+#[path = "**/*.jsx"]
+#[path = "**/*.mjs"]
+pub fn javascript() {
+    until /$/ {
+        yield other;
+
+        if /\/\/.*/ {
+            yield comment;
+        } else if /\/\*/ {
+            loop {
+                yield comment;
+                await input;
+                if /\*\// {
+                    yield comment;
+                    break;
+                }
+            }
+        } else if /'/ {
+            until /$/ {
+                yield string;
+                if /\\./ {}
+                else if /'/ { yield string; break; }
+                await input;
+            }
+        } else if /"/ {
+            until /$/ {
+                yield string;
+                if /\\./ {}
+                else if /"/ { yield string; break; }
+                await input;
+            }
+        } else if /`/ {
+            loop {
+                yield string;
+                if /\\./ {}
+                else if /`/ { yield string; break; }
+                await input;
+            }
+        } else if /(?:if|else|switch|case|default|for|while|do|break|continue|try|catch|finally|throw|return)\>/ {
+            if /\w+/ {
+                yield other;
+            } else {
+                yield keyword.control;
+            }
+        } else if /(?:async|await|class|const|delete|export|extends|function|import|in|instanceof|let|new|of|super|this|typeof|var|void|yield)\>/ {
+            if /\w+/ {
+                yield other;
+            } else {
+                yield keyword.other;
+            }
+        } else if /(?:true|false|null|undefined|NaN|Infinity)\>/ {
+            if /\w+/ {
+                yield other;
+            } else {
+                yield constant.language;
+            }
+        } else if /-?(?:0[xX][\da-fA-F]+|0[bB][01]+|0[oO][0-7]+|\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/ {
+            if /\w+/ {
+                yield other;
+            } else {
+                yield constant.numeric;
+            }
+        } else if /([A-Za-z_$][\w$]*)\s*\(/ {
+            yield $1 as method;
+        } else if /[A-Za-z_$][\w$]*/ {
+            // Gobble any other tokens that should not be highlighted
+        }
+
+        yield other;
+    }
+}

--- a/crates/lsh/definitions/javascript.lsh
+++ b/crates/lsh/definitions/javascript.lsh
@@ -57,7 +57,7 @@ pub fn javascript() {
             } else {
                 yield constant.language;
             }
-        } else if /-?(?:0[xX][\da-fA-F]+|0[bB][01]+|0[oO][0-7]+|\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/ {
+        } else if /-?(?:(?i:0x[\da-fA-F]+)|(?i:0b[01]+)|(?i:0o[0-7]+)|\d+\.?\d*|\.\d+)(?i:e[+-]?\d+)?/ {
             if /\w+/ {
                 yield other;
             } else {

--- a/crates/lsh/definitions/markdown.lsh
+++ b/crates/lsh/definitions/markdown.lsh
@@ -18,7 +18,27 @@ pub fn markdown() {
         yield comment;
     } else if /```/ {
         // NOTE: These checks are sorted alphabetically.
-        if /(?i:diff)/ {
+        if /(?i:bash|sh|shell)/ {
+            loop {
+                await input;
+                if /\s*```/ {
+                    return;
+                } else {
+                    bash();
+                    if /.*/ {}
+                }
+            }
+        } else if /(?i:zsh)/ {
+            loop {
+                await input;
+                if /\s*```/ {
+                    return;
+                } else {
+                    zsh();
+                    if /.*/ {}
+                }
+            }
+        } else if /(?i:diff)/ {
             loop {
                 await input;
                 if /\s*```/ {
@@ -30,6 +50,16 @@ pub fn markdown() {
                     if /.*/ {}
                 }
             }
+        } else if /(?i:javascript|js|jsx|mjs|cjs)/ {
+            loop {
+                await input;
+                if /\s*```/ {
+                    return;
+                } else {
+                    javascript();
+                    if /.*/ {}
+                }
+            }
         } else if /(?i:json)/ {
             loop {
                 await input;
@@ -37,6 +67,16 @@ pub fn markdown() {
                     return;
                 } else {
                     json();
+                    if /.*/ {}
+                }
+            }
+        } else if /(?i:py|python)/ {
+            loop {
+                await input;
+                if /\s*```/ {
+                    return;
+                } else {
+                    python();
                     if /.*/ {}
                 }
             }

--- a/crates/lsh/definitions/python.lsh
+++ b/crates/lsh/definitions/python.lsh
@@ -52,7 +52,7 @@ pub fn python() {
             } else {
                 yield constant.language;
             }
-        } else if /-?(?:0[xX][\da-fA-F]+|0[bB][01]+|0[oO][0-7]+|\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?(?:[jJ])?/ {
+        } else if /-?(?:(?i:0x[\da-fA-F]+)|(?i:0b[01]+)|(?i:0o[0-7]+)|\d+\.?\d*|\.\d+)(?i:e[+-]?\d+)?(?i:j)?/ {
             if /\w+/ {
                 yield other;
             } else {

--- a/crates/lsh/definitions/python.lsh
+++ b/crates/lsh/definitions/python.lsh
@@ -1,0 +1,71 @@
+#[display_name = "Python"]
+#[path = "**/*.py"]
+#[path = "**/*.pyi"]
+#[path = "**/*.pyw"]
+pub fn python() {
+    until /$/ {
+        yield other;
+
+        if /#.*/ {
+            yield comment;
+        } else if /'''/ {
+            loop {
+                yield string;
+                if /'''/ { yield string; break; }
+                await input;
+            }
+        } else if /"""/ {
+            loop {
+                yield string;
+                if /"""/ { yield string; break; }
+                await input;
+            }
+        } else if /'/ {
+            until /$/ {
+                yield string;
+                if /\\./ {}
+                else if /'/ { yield string; break; }
+                await input;
+            }
+        } else if /"/ {
+            until /$/ {
+                yield string;
+                if /\\./ {}
+                else if /"/ { yield string; break; }
+                await input;
+            }
+        } else if /(?:if|elif|else|for|while|try|except|finally|return|break|continue|raise|with|match|case|pass)\>/ {
+            if /\w+/ {
+                yield other;
+            } else {
+                yield keyword.control;
+            }
+        } else if /(?:and|as|assert|async|await|class|def|del|from|global|import|in|is|lambda|nonlocal|not|or|yield)\>/ {
+            if /\w+/ {
+                yield other;
+            } else {
+                yield keyword.other;
+            }
+        } else if /(?:True|False|None)\>/ {
+            if /\w+/ {
+                yield other;
+            } else {
+                yield constant.language;
+            }
+        } else if /-?(?:0[xX][\da-fA-F]+|0[bB][01]+|0[oO][0-7]+|\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?(?:[jJ])?/ {
+            if /\w+/ {
+                yield other;
+            } else {
+                yield constant.numeric;
+            }
+        } else if /@[A-Za-z_]\w*/ {
+            yield markup.link;
+        } else if /([A-Za-z_]\w*)\s*\(/ {
+            yield $1 as method;
+        } else if /[A-Za-z_]\w*/ {
+            // Gobble any other tokens that should not be highlighted
+        }
+
+        yield other;
+    }
+}

--- a/crates/lsh/definitions/zsh.lsh
+++ b/crates/lsh/definitions/zsh.lsh
@@ -1,0 +1,60 @@
+#[display_name = "Zsh"]
+#[path = "**/*.zsh"]
+#[path = "**/.zprofile"]
+#[path = "**/.zshenv"]
+#[path = "**/.zshrc"]
+pub fn zsh() {
+    until /$/ {
+        yield other;
+
+        if /#.*/ {
+            yield comment;
+        } else if /'/ {
+            until /$/ {
+                yield string;
+                if /'/ { yield string; break; }
+                await input;
+            }
+        } else if /"/ {
+            until /$/ {
+                yield string;
+                if /\\./ {}
+                else if /"/ { yield string; break; }
+                await input;
+            }
+        } else if /`/ {
+            until /$/ {
+                yield string;
+                if /\\./ {}
+                else if /`/ { yield string; break; }
+                await input;
+            }
+        } else if /\$\{[^}]+\}|\$[A-Za-z_]\w*|\$\d+|\$[#?*!@$-]/ {
+            yield variable;
+        } else if /(?:if|then|elif|else|fi|for|while|until|do|done|case|esac|in|select)\>/ {
+            if /\w+/ {
+                yield other;
+            } else {
+                yield keyword.control;
+            }
+        } else if /(?:alias|autoload|bindkey|compdef|declare|emulate|export|function|local|readonly|setopt|source|typeset|unalias|unsetopt|zmodload)\>/ {
+            if /\w+/ {
+                yield other;
+            } else {
+                yield keyword.other;
+            }
+        } else if /-?(?:0[xX][\da-fA-F]+|\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/ {
+            if /\w+/ {
+                yield other;
+            } else {
+                yield constant.numeric;
+            }
+        } else if /([A-Za-z_][\w-]*)\s*\(/ {
+            yield $1 as method;
+        } else if /[A-Za-z_][\w-]*/ {
+            // Gobble any other tokens that should not be highlighted
+        }
+
+        yield other;
+    }
+}

--- a/crates/lsh/definitions/zsh.lsh
+++ b/crates/lsh/definitions/zsh.lsh
@@ -43,7 +43,7 @@ pub fn zsh() {
             } else {
                 yield keyword.other;
             }
-        } else if /-?(?:0[xX][\da-fA-F]+|\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/ {
+        } else if /-?(?:(?i:0x[\da-fA-F]+)|\d+\.?\d*|\.\d+)(?i:e[+-]?\d+)?/ {
             if /\w+/ {
                 yield other;
             } else {


### PR DESCRIPTION
This adds initial LSH syntax highlighting support for:

- Bash
- Zsh
- Python
- JavaScript

It also updates Markdown fenced code block routing so that:

- `bash`, `sh`, and `shell` use Bash highlighting
- `zsh` uses Zsh highlighting
- `python` / `py` use Python highlighting
- `javascript` / `js` / `jsx` / `mjs` / `cjs` use JavaScript highlighting

## Scope

This is a lightweight LSH-only change with no new dependencies.

The changes are limited to syntax definitions and highlighting fixtures:
- new LSH definitions for the languages above
- Markdown fenced code block routing updates
- new / expanded highlighting test samples

## Validation

- `cargo test -q`

## Notes

The new rules are intentionally simple and follow the style of the existing LSH definitions.
They focus on the main token classes already used elsewhere in the project, such as:

- comments
- strings
- keywords
- language constants
- numeric literals
- common function-style identifiers

If you would prefer this to be discussed as a feature request first, I am happy to open an issue and rework the PR accordingly.