### PR TITLE
Add theme support for customizable colors

### DIFF
--- a/crates/edit/src/bin/edit/documents.rs
+++ b/crates/edit/src/bin/edit/documents.rs
@@ -285,6 +285,12 @@ impl DocumentManager {
             tb.set_insert_final_newline(!cfg!(windows)); // As mandated by POSIX.
             tb.set_margin_enabled(true);
             tb.set_line_highlight_enabled(true);
+
+            // Apply theme colors
+            let settings = Settings::borrow();
+            let theme = &settings.theme;
+            tb.set_line_number_color(theme.line_number);
+            tb.set_line_highlight_color(theme.line_highlight);
         }
         Ok(buffer)
     }

--- a/crates/edit/src/bin/edit/main.rs
+++ b/crates/edit/src/bin/edit/main.rs
@@ -20,7 +20,7 @@ use draw_editor::*;
 use draw_filepicker::*;
 use draw_menubar::*;
 use draw_statusbar::*;
-use edit::framebuffer::{self, IndexedColor};
+use edit::framebuffer::{self, INDEXED_COLORS_COUNT, IndexedColor};
 use edit::helpers::*;
 use edit::input::{self, kbmod, vk};
 use edit::oklab::StraightRgba;
@@ -558,6 +558,98 @@ impl Drop for RestoreModes {
     }
 }
 
+/// Apply user-defined theme colors to the indexed_colors array.
+/// Returns a boolean array indicating which colors were user-configured.
+/// User-configured colors take priority over terminal-reported colors.
+fn apply_user_theme(
+    indexed_colors: &mut [StraightRgba; INDEXED_COLORS_COUNT],
+) -> [bool; INDEXED_COLORS_COUNT] {
+    use crate::settings::Settings;
+    use edit::framebuffer::IndexedColor;
+
+    let settings = Settings::borrow();
+    let theme = &settings.theme;
+    let mut user_configured = [false; INDEXED_COLORS_COUNT];
+
+    // Apply standard 16 colors
+    if let Some(c) = theme.black {
+        indexed_colors[IndexedColor::Black as usize] = c;
+        user_configured[IndexedColor::Black as usize] = true;
+    }
+    if let Some(c) = theme.red {
+        indexed_colors[IndexedColor::Red as usize] = c;
+        user_configured[IndexedColor::Red as usize] = true;
+    }
+    if let Some(c) = theme.green {
+        indexed_colors[IndexedColor::Green as usize] = c;
+        user_configured[IndexedColor::Green as usize] = true;
+    }
+    if let Some(c) = theme.yellow {
+        indexed_colors[IndexedColor::Yellow as usize] = c;
+        user_configured[IndexedColor::Yellow as usize] = true;
+    }
+    if let Some(c) = theme.blue {
+        indexed_colors[IndexedColor::Blue as usize] = c;
+        user_configured[IndexedColor::Blue as usize] = true;
+    }
+    if let Some(c) = theme.magenta {
+        indexed_colors[IndexedColor::Magenta as usize] = c;
+        user_configured[IndexedColor::Magenta as usize] = true;
+    }
+    if let Some(c) = theme.cyan {
+        indexed_colors[IndexedColor::Cyan as usize] = c;
+        user_configured[IndexedColor::Cyan as usize] = true;
+    }
+    if let Some(c) = theme.white {
+        indexed_colors[IndexedColor::White as usize] = c;
+        user_configured[IndexedColor::White as usize] = true;
+    }
+    if let Some(c) = theme.bright_black {
+        indexed_colors[IndexedColor::BrightBlack as usize] = c;
+        user_configured[IndexedColor::BrightBlack as usize] = true;
+    }
+    if let Some(c) = theme.bright_red {
+        indexed_colors[IndexedColor::BrightRed as usize] = c;
+        user_configured[IndexedColor::BrightRed as usize] = true;
+    }
+    if let Some(c) = theme.bright_green {
+        indexed_colors[IndexedColor::BrightGreen as usize] = c;
+        user_configured[IndexedColor::BrightGreen as usize] = true;
+    }
+    if let Some(c) = theme.bright_yellow {
+        indexed_colors[IndexedColor::BrightYellow as usize] = c;
+        user_configured[IndexedColor::BrightYellow as usize] = true;
+    }
+    if let Some(c) = theme.bright_blue {
+        indexed_colors[IndexedColor::BrightBlue as usize] = c;
+        user_configured[IndexedColor::BrightBlue as usize] = true;
+    }
+    if let Some(c) = theme.bright_magenta {
+        indexed_colors[IndexedColor::BrightMagenta as usize] = c;
+        user_configured[IndexedColor::BrightMagenta as usize] = true;
+    }
+    if let Some(c) = theme.bright_cyan {
+        indexed_colors[IndexedColor::BrightCyan as usize] = c;
+        user_configured[IndexedColor::BrightCyan as usize] = true;
+    }
+    if let Some(c) = theme.bright_white {
+        indexed_colors[IndexedColor::BrightWhite as usize] = c;
+        user_configured[IndexedColor::BrightWhite as usize] = true;
+    }
+
+    // Apply special colors
+    if let Some(c) = theme.background {
+        indexed_colors[IndexedColor::Background as usize] = c;
+        user_configured[IndexedColor::Background as usize] = true;
+    }
+    if let Some(c) = theme.foreground {
+        indexed_colors[IndexedColor::Foreground as usize] = c;
+        user_configured[IndexedColor::Foreground as usize] = true;
+    }
+
+    user_configured
+}
+
 fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) -> RestoreModes {
     sys::write_stdout(concat!(
         // 1049: Alternative Screen Buffer
@@ -588,8 +680,11 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
     let mut done = false;
     let mut osc_buffer = String::new();
     let mut indexed_colors = framebuffer::DEFAULT_THEME;
-    let mut color_responses = 0;
+    let mut _color_responses = 0;
     let mut ambiguous_width = 1;
+
+    // Apply user-defined theme colors first (highest priority)
+    let user_configured = apply_user_theme(&mut indexed_colors);
 
     while !done {
         let scratch = scratch_arena(None);
@@ -622,18 +717,27 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
 
                     let mut splits = data.split_terminator(';');
 
-                    let color = match splits.next().unwrap_or("") {
+                    let color_idx = match splits.next().unwrap_or("") {
                         // The response is `4;<color>;rgb:<r>/<g>/<b>`.
                         "4" => match splits.next().unwrap_or("").parse::<usize>() {
-                            Ok(val) if val < 16 => &mut indexed_colors[val],
+                            Ok(val) if val < 16 => val,
                             _ => continue,
                         },
                         // The response is `10;rgb:<r>/<g>/<b>`.
-                        "10" => &mut indexed_colors[IndexedColor::Foreground as usize],
+                        "10" => IndexedColor::Foreground as usize,
                         // The response is `11;rgb:<r>/<g>/<b>`.
-                        "11" => &mut indexed_colors[IndexedColor::Background as usize],
+                        "11" => IndexedColor::Background as usize,
                         _ => continue,
                     };
+
+                    // Skip if this color was user-configured (user theme has priority)
+                    if user_configured[color_idx] {
+                        _color_responses += 1;
+                        osc_buffer.clear();
+                        continue;
+                    }
+
+                    let color = &mut indexed_colors[color_idx];
 
                     let color_param = splits.next().unwrap_or("");
                     if !color_param.starts_with("rgb:") {
@@ -658,7 +762,7 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
                     }
 
                     *color = StraightRgba::from_le(rgb | 0xff000000);
-                    color_responses += 1;
+                    _color_responses += 1;
                     osc_buffer.clear();
                 }
                 _ => {}
@@ -671,9 +775,10 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
         state.documents.reflow_all();
     }
 
-    if color_responses == indexed_colors.len() {
-        tui.setup_indexed_colors(indexed_colors);
-    }
+    // Always apply colors: user-configured colors take priority,
+    // terminal-reported colors fill in the rest,
+    // and DEFAULT_THEME is the fallback.
+    tui.setup_indexed_colors(indexed_colors);
 
     RestoreModes
 }

--- a/crates/edit/src/bin/edit/settings.rs
+++ b/crates/edit/src/bin/edit/settings.rs
@@ -4,14 +4,74 @@ use edit::buffer::TextBuffer;
 use edit::cell::{Ref, SemiRefCell};
 use edit::json;
 use edit::lsh::{LANGUAGES, Language};
+use edit::oklab::StraightRgba;
 use stdext::arena::{read_to_string, scratch_arena};
 use stdext::arena_format;
 
 use crate::apperr;
 
+/// Theme configuration with user-defined colors.
+/// All colors are in RRGGBBAA format (same as framebuffer).
+#[derive(Clone, Copy, Debug)]
+pub struct ThemeConfig {
+    // Standard 16 terminal colors
+    pub black: Option<StraightRgba>,
+    pub red: Option<StraightRgba>,
+    pub green: Option<StraightRgba>,
+    pub yellow: Option<StraightRgba>,
+    pub blue: Option<StraightRgba>,
+    pub magenta: Option<StraightRgba>,
+    pub cyan: Option<StraightRgba>,
+    pub white: Option<StraightRgba>,
+    pub bright_black: Option<StraightRgba>,
+    pub bright_red: Option<StraightRgba>,
+    pub bright_green: Option<StraightRgba>,
+    pub bright_yellow: Option<StraightRgba>,
+    pub bright_blue: Option<StraightRgba>,
+    pub bright_magenta: Option<StraightRgba>,
+    pub bright_cyan: Option<StraightRgba>,
+    pub bright_white: Option<StraightRgba>,
+    // Special colors
+    pub background: Option<StraightRgba>,
+    pub foreground: Option<StraightRgba>,
+    // UI colors
+    pub line_number: Option<StraightRgba>,
+    pub line_highlight: Option<StraightRgba>,
+}
+
+impl ThemeConfig {
+    /// Create an empty theme config (all colors are None)
+    pub const fn empty() -> Self {
+        Self {
+            black: None,
+            red: None,
+            green: None,
+            yellow: None,
+            blue: None,
+            magenta: None,
+            cyan: None,
+            white: None,
+            bright_black: None,
+            bright_red: None,
+            bright_green: None,
+            bright_yellow: None,
+            bright_blue: None,
+            bright_magenta: None,
+            bright_cyan: None,
+            bright_white: None,
+            background: None,
+            foreground: None,
+            line_number: None,
+            line_highlight: None,
+        }
+    }
+
+}
+
 pub struct Settings {
     pub path: PathBuf,
     pub file_associations: Vec<(String, &'static Language)>,
+    pub theme: ThemeConfig,
 }
 
 struct SettingsCell(SemiRefCell<Settings>);
@@ -28,7 +88,11 @@ impl Settings {
     }
 
     const fn new() -> Self {
-        Settings { path: PathBuf::new(), file_associations: Vec::new() }
+        Settings {
+            path: PathBuf::new(),
+            file_associations: Vec::new(),
+            theme: ThemeConfig::empty(),
+        }
     }
 
     pub fn borrow() -> Ref<'static, Settings> {
@@ -82,8 +146,73 @@ impl Settings {
             }
         }
 
+        // Parse theme configuration
+        if let Some(theme_obj) = root.get_object("theme") {
+            self.theme = parse_theme_config(theme_obj)?;
+        }
+
         Ok(())
     }
+}
+
+/// Parse a hex color string (with or without # prefix) into StraightRgba
+/// Supports: RRGGBB, #RRGGBB, RRGGBBAA, #RRGGBBAA
+/// Format matches the framebuffer's DEFAULT_THEME (RRGGBBAA in big-endian)
+fn parse_hex_color(s: &str) -> Option<StraightRgba> {
+    let s = s.trim();
+    let s = s.strip_prefix('#').unwrap_or(s);
+
+    let val = u32::from_str_radix(s, 16).ok()?;
+
+    // Convert to RRGGBBAA format (same as DEFAULT_THEME in framebuffer.rs)
+    let rgba = match s.len() {
+        6 => StraightRgba::from_be(val << 8 | 0xFF), // RRGGBB -> RRGGBBFF
+        8 => StraightRgba::from_be(val),             // RRGGBBAA
+        _ => return None,
+    };
+
+    Some(rgba)
+}
+
+/// Parse theme configuration from JSON object
+fn parse_theme_config(obj: edit::json::Object) -> apperr::Result<ThemeConfig> {
+    let mut theme = ThemeConfig::empty();
+
+    for &(key, ref value) in obj.iter() {
+        let Some(color_str) = value.as_str() else {
+            return Err(apperr::Error::SettingsInvalid("theme color value must be a string"));
+        };
+
+        let Some(color) = parse_hex_color(color_str) else {
+            return Err(apperr::Error::SettingsInvalid("invalid color format"));
+        };
+
+        match key {
+            "black" => theme.black = Some(color),
+            "red" => theme.red = Some(color),
+            "green" => theme.green = Some(color),
+            "yellow" => theme.yellow = Some(color),
+            "blue" => theme.blue = Some(color),
+            "magenta" => theme.magenta = Some(color),
+            "cyan" => theme.cyan = Some(color),
+            "white" => theme.white = Some(color),
+            "brightBlack" | "bright_black" => theme.bright_black = Some(color),
+            "brightRed" | "bright_red" => theme.bright_red = Some(color),
+            "brightGreen" | "bright_green" => theme.bright_green = Some(color),
+            "brightYellow" | "bright_yellow" => theme.bright_yellow = Some(color),
+            "brightBlue" | "bright_blue" => theme.bright_blue = Some(color),
+            "brightMagenta" | "bright_magenta" => theme.bright_magenta = Some(color),
+            "brightCyan" | "bright_cyan" => theme.bright_cyan = Some(color),
+            "brightWhite" | "bright_white" => theme.bright_white = Some(color),
+            "background" | "bg" => theme.background = Some(color),
+            "foreground" | "fg" => theme.foreground = Some(color),
+            "lineNumber" | "line_number" => theme.line_number = Some(color),
+            "lineHighlight" | "line_highlight" => theme.line_highlight = Some(color),
+            _ => {} // Unknown theme key, ignore
+        }
+    }
+
+    Ok(theme)
 }
 
 fn settings_json_path() -> Option<PathBuf> {

--- a/crates/edit/src/buffer/mod.rs
+++ b/crates/edit/src/buffer/mod.rs
@@ -262,6 +262,8 @@ pub struct TextBuffer {
     tab_size: CoordType,
     indent_with_tabs: bool,
     line_highlight_enabled: bool,
+    line_number_color: Option<StraightRgba>,
+    line_highlight_color: Option<StraightRgba>,
     language: Option<&'static Language>,
     ruler: CoordType,
     encoding: &'static str,
@@ -312,6 +314,8 @@ impl TextBuffer {
             tab_size: 4,
             indent_with_tabs: false,
             line_highlight_enabled: false,
+            line_number_color: None,
+            line_highlight_color: None,
             language: None,
             ruler: 0,
             encoding: "UTF-8",
@@ -605,6 +609,16 @@ impl TextBuffer {
     /// Sets whether the line the cursor is on should be highlighted.
     pub fn set_line_highlight_enabled(&mut self, enabled: bool) {
         self.line_highlight_enabled = enabled;
+    }
+
+    /// Set the color for line numbers in the margin.
+    pub fn set_line_number_color(&mut self, color: Option<StraightRgba>) {
+        self.line_number_color = color;
+    }
+
+    /// Set the background color for the current line highlight.
+    pub fn set_line_highlight_color(&mut self, color: Option<StraightRgba>) {
+        self.line_highlight_color = color;
     }
 
     pub fn language(&self) -> Option<&'static Language> {
@@ -2023,7 +2037,9 @@ impl TextBuffer {
                 right: destination.left + self.margin_width,
                 bottom: destination.bottom,
             };
-            fb.blend_fg(margin, StraightRgba::from_le(0x7f7f7f7f));
+            let line_number_color =
+                self.line_number_color.unwrap_or_else(|| StraightRgba::from_le(0x7f7f7f7f));
+            fb.blend_fg(margin, line_number_color);
         }
 
         if self.ruler > 0 {
@@ -2064,6 +2080,9 @@ impl TextBuffer {
                 fb.set_cursor(cursor, self.overtype);
 
                 if self.line_highlight_enabled && selection_beg >= selection_end {
+                    let highlight_color = self
+                        .line_highlight_color
+                        .unwrap_or_else(|| StraightRgba::from_le(0x7f7f7f7f));
                     fb.blend_bg(
                         Rect {
                             left: destination.left,
@@ -2071,7 +2090,7 @@ impl TextBuffer {
                             right: destination.right,
                             bottom: cursor.y + 1,
                         },
-                        StraightRgba::from_le(0x7f7f7f7f),
+                        highlight_color,
                     );
                 }
             }

--- a/crates/edit/src/framebuffer.rs
+++ b/crates/edit/src/framebuffer.rs
@@ -142,8 +142,8 @@ impl Framebuffer {
     /// successfully detect the light/dark mode of the terminal.
     pub fn set_indexed_colors(&mut self, colors: [StraightRgba; INDEXED_COLORS_COUNT]) {
         self.indexed_colors = colors;
-        self.background_fill = StraightRgba::zero();
-        self.foreground_fill = StraightRgba::zero();
+        self.background_fill = self.indexed_colors[IndexedColor::Background as usize];
+        self.foreground_fill = self.indexed_colors[IndexedColor::Foreground as usize];
 
         self.auto_colors = [
             self.indexed_colors[IndexedColor::Black as usize],


### PR DESCRIPTION
Add theme support for customizable colors, format: RGB/RGBA

# Example config

  ```json
{
  "theme": {
    "black": "#000000",
    "red": "#FF0000FF",
    "green": "#00FF00",
    "yellow": "#FFFF00FF",
    "blue": "#204DBE",
    "magenta": "#FF00FFFF",
    "cyan": "#00A7B2",
    "white": "#FFFFFFFF",
    "brightBlack": "#808080",
    "brightRed": "#FF3E30FF",
    "brightGreen": "#58EA51",
    "brightYellow": "#FFC944FF",
    "brightBlue": "#2F6AFF",
    "brightMagenta": "#FC74FFFF",
    "brightCyan": "#00E1F0",
    "brightWhite": "#FFFFFFFF",
    "background": "#0C0C0C",
    "foreground": "#00FF00FF",
    "lineNumber": "#FF00FF",
    "lineHighlight": "#00FF00FF"
  }
}

  ```

# Scope

  This is a lightweight change with no new dependencies.

  The changes are limited to:

 - settings.rs: Theme config parsing and storage
 - documents.rs: Apply theme colors when creating buffers
 - buffer/mod.rs: TextBuffer color setters
 - main.rs: Apply user theme colors to indexed colors array
 - framebuffer.rs: Fix background/foreground color application from indexed colors

 # Validation

  cargo test -q

 # Notes

  - All theme fields are optional; omitted colors fall back to defaults
  - The theme configuration reuses the existing settings.json
  - Binary size increase 5KB (+1.3%) (measured with cargo build --release)

Only tested on Windows 11 with cargo 1.86.0

# Screenshot
<img width="2064" height="1134" alt="ScreenShot_2026-04-16_13-34-18" src="https://github.com/user-attachments/assets/d11a507d-6b1a-4c89-8956-ebef6a8adc9c" />
