### PR TITLE
Align LSH language IDs with VS Code

### DIFF
--- a/crates/lsh/definitions/git_commit.lsh
+++ b/crates/lsh/definitions/git_commit.lsh
@@ -1,7 +1,7 @@
 #[display_name = "Git Commit Message"]
 #[path = "**/COMMIT_EDITMSG"]
 #[path = "**/MERGE_MSG"]
-pub fn git_commit_message() {
+pub fn git_commit() {
     if /#\s*/ {
         yield comment;
         if /(?:modified:|renamed:).*/ {

--- a/crates/lsh/definitions/git_rebase.lsh
+++ b/crates/lsh/definitions/git_rebase.lsh
@@ -1,7 +1,7 @@
 #[display_name = "Git Rebase Message"]
 #[path = "**/git-rebase-todo"]
 #[path = "**/rebase-merge/done"]
-pub fn git_rebase_todo() {
+pub fn git_rebase() {
     if /#.*/ {
         yield comment;
     } else if /(?:break|exec|b|x)\>/ {

--- a/crates/lsh/definitions/ignore.lsh
+++ b/crates/lsh/definitions/ignore.lsh
@@ -1,7 +1,7 @@
 #[display_name = "Ignore"]
 #[path = "**/.git-blame-ignore-revs"]
 #[path = "**/.gitignore"]
-pub fn git_ignore() {
+pub fn ignore() {
     if /#.*/ {
         yield comment;
     }

--- a/crates/lsh/src/compiler/generator.rs
+++ b/crates/lsh/src/compiler/generator.rs
@@ -216,7 +216,9 @@ impl TryFrom<u32> for HighlightKind {{
             _ = writeln!(
                 output,
                 "    Language {{ id: {:?}, name: {:?}, entrypoint: {} }},",
-                ep.name, ep.display_name, ep.address
+                ep.name.replace('_', "-"),
+                ep.display_name,
+                ep.address,
             );
         }
         output.push_str("];\n");


### PR DESCRIPTION
This turns "git_commit_message" into "git-commit".