### PR TITLE
Fix reading redirected input from stdin

### DIFF
--- a/crates/edit/src/bin/edit/main.rs
+++ b/crates/edit/src/bin/edit/main.rs
@@ -75,12 +75,13 @@ fn run() -> apperr::Result<()> {
         return Ok(());
     }
 
+    handle_stdin(&mut state)?;
+
     if let Err(err) = Settings::reload() {
         state.add_error(err);
     }
 
-    // This will reopen stdin if it's redirected (which may fail) and switch
-    // the terminal to raw mode which prevents the user from pressing Ctrl+C.
+    // Switch the terminal to raw mode which prevents the user from pressing Ctrl+C.
     // `handle_args` may want to print a help message (must not fail),
     // and reads files (may hang; should be cancelable with Ctrl+C).
     // As such, we call this after `handle_args`.
@@ -276,16 +277,6 @@ fn handle_args(state: &mut State) -> apperr::Result<bool> {
         state.documents.add_file_path(p)?;
     }
 
-    if let Some(mut file) = sys::open_stdin_if_redirected() {
-        let doc = state.documents.add_untitled()?;
-        let mut tb = doc.buffer.borrow_mut();
-        tb.read_file(&mut file, None)?;
-        tb.mark_as_dirty();
-    } else if paths.is_empty() {
-        // No files were passed, and stdin is not redirected.
-        state.documents.add_untitled()?;
-    }
-
     if dir.is_none()
         && let Some(parent) = paths.last().and_then(|p| p.parent())
     {
@@ -294,6 +285,22 @@ fn handle_args(state: &mut State) -> apperr::Result<bool> {
 
     state.file_picker_pending_dir = DisplayablePathBuf::from_path(dir.unwrap_or(cwd));
     Ok(false)
+}
+
+// Read any redirected (piped) stdin into a new document.
+// This doubles as a stdin handle validation. We do this after `handle_args`
+// (may exit early) and before `switch_modes` (needs a console stdin).
+fn handle_stdin(state: &mut State) -> apperr::Result<()> {
+    if let Some(mut file) = sys::reopen_stdin_if_redirected()? {
+        let doc = state.documents.add_untitled()?;
+        let mut tb = doc.buffer.borrow_mut();
+        tb.read_file(&mut file, None)?;
+        tb.mark_as_dirty();
+    } else if state.documents.len() == 0 {
+        // No files were passed, and stdin is not redirected.
+        state.documents.add_untitled()?;
+    }
+    Ok(())
 }
 
 fn print_help() {

--- a/crates/edit/src/sys/unix.rs
+++ b/crates/edit/src/sys/unix.rs
@@ -51,13 +51,20 @@ pub fn init() -> Deinit {
     Deinit
 }
 
-pub fn switch_modes() -> io::Result<()> {
+/// Reopen stdin if it's redirected (= piped input).
+pub fn reopen_stdin_if_redirected() -> io::Result<Option<File>> {
     unsafe {
-        // Reopen stdin if it's redirected (= piped input).
         if libc::isatty(STATE.stdin) == 0 {
             STATE.stdin = check_int_return(libc::open(c"/dev/tty".as_ptr(), libc::O_RDONLY))?;
+            Ok(Some(File::from_raw_fd(libc::STDIN_FILENO)))
+        } else {
+            Ok(None)
         }
+    }
+}
 
+pub fn switch_modes() -> io::Result<()> {
+    unsafe {
         // Store the stdin flags so we can more easily toggle `O_NONBLOCK` later on.
         STATE.stdin_flags = check_int_return(libc::fcntl(STATE.stdin, libc::F_GETFL))?;
 
@@ -329,17 +336,6 @@ fn set_tty_nonblocking(nonblock: bool) {
         if is_nonblock != nonblock {
             STATE.stdin_flags ^= libc::O_NONBLOCK;
             let _ = libc::fcntl(STATE.stdin, libc::F_SETFL, STATE.stdin_flags);
-        }
-    }
-}
-
-pub fn open_stdin_if_redirected() -> Option<File> {
-    unsafe {
-        // Did we reopen stdin during `init()`?
-        if STATE.stdin != libc::STDIN_FILENO {
-            Some(File::from_raw_fd(libc::STDIN_FILENO))
-        } else {
-            None
         }
     }
 }

--- a/crates/edit/src/sys/windows.rs
+++ b/crates/edit/src/sys/windows.rs
@@ -115,6 +115,38 @@ pub fn init() -> Deinit {
     }
 }
 
+/// Reopen stdin if it's redirected (= piped input).
+pub fn reopen_stdin_if_redirected() -> io::Result<Option<File>> {
+    unsafe {
+        let stdin = STATE.stdin;
+
+        if stdin != Foundation::INVALID_HANDLE_VALUE
+            && FileSystem::GetFileType(stdin) == FileSystem::FILE_TYPE_CHAR
+        {
+            return Ok(None); // stdin refers to a TTY
+        }
+
+        STATE.stdin = FileSystem::CreateFileW(
+            w!("CONIN$"),
+            Foundation::GENERIC_READ | Foundation::GENERIC_WRITE,
+            FileSystem::FILE_SHARE_READ | FileSystem::FILE_SHARE_WRITE,
+            null_mut(),
+            FileSystem::OPEN_EXISTING,
+            0,
+            null_mut(),
+        );
+        if STATE.stdin == Foundation::INVALID_HANDLE_VALUE {
+            return Err(last_os_error());
+        }
+
+        if stdin != Foundation::INVALID_HANDLE_VALUE {
+            Ok(Some(File::from_raw_handle(stdin)))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
 /// Switches the terminal into raw mode, etc.
 pub fn switch_modes() -> io::Result<()> {
     unsafe {
@@ -138,20 +170,6 @@ pub fn switch_modes() -> io::Result<()> {
             },
         };
 
-        // Reopen stdin if it's redirected (= piped input).
-        if ptr::eq(STATE.stdin, Foundation::INVALID_HANDLE_VALUE)
-            || !matches!(FileSystem::GetFileType(STATE.stdin), FileSystem::FILE_TYPE_CHAR)
-        {
-            STATE.stdin = FileSystem::CreateFileW(
-                w!("CONIN$"),
-                Foundation::GENERIC_READ | Foundation::GENERIC_WRITE,
-                FileSystem::FILE_SHARE_READ | FileSystem::FILE_SHARE_WRITE,
-                null_mut(),
-                FileSystem::OPEN_EXISTING,
-                0,
-                null_mut(),
-            );
-        }
         if ptr::eq(STATE.stdin, Foundation::INVALID_HANDLE_VALUE)
             || ptr::eq(STATE.stdout, Foundation::INVALID_HANDLE_VALUE)
         {
@@ -411,20 +429,6 @@ pub fn write_stdout(text: &str) {
                 break;
             }
         }
-    }
-}
-
-/// Check if the stdin handle is redirected to a file, etc.
-///
-/// # Returns
-///
-/// * `Some(file)` if stdin is redirected.
-/// * Otherwise, `None`.
-pub fn open_stdin_if_redirected() -> Option<File> {
-    unsafe {
-        let handle = Console::GetStdHandle(Console::STD_INPUT_HANDLE);
-        // Did we reopen stdin during `init()`?
-        if !std::ptr::eq(STATE.stdin, handle) { Some(File::from_raw_handle(handle)) } else { None }
     }
 }
 


### PR DESCRIPTION
This broke in #556, which moved the stdin reopen from `init()` into
`switch_modes()`. But `open_stdin_if_redirected()` was called inside
`handle_args()`, which runs before `switch_modes()`.
So, after #556, it would never see the reopened `stdin`.