### PR TITLE
Fix stdarch_loongarch support in stdext

### DIFF
--- a/crates/stdext/src/lib.rs
+++ b/crates/stdext/src/lib.rs
@@ -3,6 +3,12 @@
 
 //! Arena allocators. Small and fast.
 
+#![cfg_attr(
+    target_arch = "loongarch64",
+    feature(stdarch_loongarch),
+    allow(clippy::incompatible_msrv)
+)]
+
 pub mod alloc;
 pub mod arena;
 pub mod collections;


### PR DESCRIPTION
Fix
```
error[E0658]: use of unstable library feature `stdarch_loongarch`
...
    = note: see issue #117427 <https://github.com/rust-lang/rust/issues/117427> for more information
    = help: add `#![feature(stdarch_loongarch)]` to the crate attributes to enable
    = note: this compiler was built on 2026-04-28; consider upgrading it if it is out of date
```
when building edit on loongarch