### PR TITLE
Add macOS Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Additional flags are `--dev`, to build directly from the main branch, and `--sys
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/microsoft/edit/main/assets/install.sh | sh -s -- --dev --system
 ```
 
+### macOS
+
+You can install the latest version with Homebrew:
+```sh
+brew install msedit
+```
+
 ## Build Instructions
 
 * [Install Rust](https://www.rust-lang.org/tools/install)


### PR DESCRIPTION

This pull request adds installation instructions for macOS users to the `README.md` file, making it easier for users on that platform to install the software using Homebrew.

* Documentation update:
  * Added a new section describing how to install the software on macOS using Homebrew in `README.md`.