### PR TITLE
Clean up Markdown formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ As such, we generally do not accept pull requests that introduce dependencies (t
 Otherwise, you can consider this project a playground for trying out any cool ideas you have.
 
 The overall architecture of the project can be summarized as follows:
+
 * The underlying text buffer in `src/buffer` doesn't keep track of line breaks in the document.
   This is a crucial design aspect that permeates throughout the entire codebase.
 
@@ -44,6 +45,7 @@ The overall architecture of the project can be summarized as follows:
   It contains a little bit of VT logic in `setup_terminal`.
 
 If you have an issue with your terminal, the places of interest are the aforementioned:
+
 * VT parser in `src/vt.rs`
 * Platform specific code in `src/sys`
 * And the `setup_terminal` function in `src/bin/edit/main.rs`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You can also download binaries from [our Releases page](https://github.com/micro
 ### Windows
 
 You can install the latest version with WinGet:
+
 ```powershell
 winget install Microsoft.Edit
 ```
@@ -22,17 +23,20 @@ winget install Microsoft.Edit
 ### Linux (build from source)
 
 If your distribution does not provide binaries, or if you'd like to build your own, you can use our install script, provided you have installed:
+
 * Rust (via `rustup` or similar)
 * A C compiler (e.g. `gcc`)
 * ICU (e.g. libicu78, libicu, icu)
 * curl/wget and tar
 
 The following command will then install `msedit` into `~/.local/bin`:
+
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/microsoft/edit/main/assets/install.sh | sh
 ```
 
 Additional flags are `--dev`, to build directly from the main branch, and `--system` to install into `/usr/local/bin`. For instance:
+
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/microsoft/edit/main/assets/install.sh | sh -s -- --dev --system
 ```
@@ -42,13 +46,16 @@ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/microsoft
 * [Install Rust](https://www.rust-lang.org/tools/install)
 * Clone the repository
 * If you're using nightly Rust:
+
   ```sh
   cargo build --release --config .cargo/release.toml
   ```
+
 * If you're using stable Rust:
   * Ideally: Set the environment variable `RUSTC_BOOTSTRAP=1` and use the **nightly** build instructions above.
     This is recommended, because it drastically reduces the binary size and slightly improves performance.
   * Otherwise, simply run:
+
     ```sh
     cargo build --release
     ```
@@ -57,10 +64,10 @@ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/microsoft
 
 You can set the following environment variables at build-time to configure the build:
 
-Environment variable | Description
---- | ---
-`EDIT_CFG_ICU*` | See [ICU library name (SONAME)](#icu-library-name-soname) below for details. Linux package maintainers are advised to review and configure these options.
-`EDIT_CFG_LANGUAGES` | A comma-separated list of languages to include in the build. See [i18n/edit.toml](i18n/edit.toml) for available languages.
+| Environment variable | Description                                                                                                                                               |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EDIT_CFG_ICU*`      | See [ICU library name (SONAME)](#icu-library-name-soname) below for details. Linux package maintainers are advised to review and configure these options. |
+| `EDIT_CFG_LANGUAGES` | A comma-separated list of languages to include in the build. See [i18n/edit.toml](i18n/edit.toml) for available languages.                                |
 
 ## Notes to Package Maintainers
 
@@ -77,12 +84,13 @@ This project optionally depends on the ICU library for its Search and Replace fu
 
 By default, the project will look for the following library names:
 
- Variable | Windows | macOS | Linux / Other
-----------|---------|-------|---------------
-`EDIT_CFG_ICUUC_SONAME` | `icuuc.dll` | `libicucore.dylib` | `libicuuc.so`
-`EDIT_CFG_ICUI18N_SONAME` | `icuin.dll` | `libicucore.dylib` | `libicui18n.so`
+ | Variable                  | Windows     | macOS              | Linux / Other   |
+ | ------------------------- | ----------- | ------------------ | --------------- |
+ | `EDIT_CFG_ICUUC_SONAME`   | `icuuc.dll` | `libicucore.dylib` | `libicuuc.so`   |
+ | `EDIT_CFG_ICUI18N_SONAME` | `icuin.dll` | `libicucore.dylib` | `libicui18n.so` |
 
 If your installation uses a different SONAME, please set the following environment variable at build time:
+
 * `EDIT_CFG_ICUUC_SONAME`:
   For instance, `libicuuc.so.76`.
 * `EDIT_CFG_ICUI18N_SONAME`:
@@ -90,6 +98,7 @@ If your installation uses a different SONAME, please set the following environme
 
 Additionally, this project assumes that the ICU exports symbols without `_` prefix and without version suffix, such as `u_errorName`.
 If your installation uses versioned exports, please set:
+
 * `EDIT_CFG_ICU_CPP_EXPORTS`:
   If set to `true`, it'll look for C++ symbols such as `_u_errorName`.
   Enabled by default on macOS.
@@ -97,12 +106,14 @@ If your installation uses versioned exports, please set:
   If set to a version number, such as `76`, it'll look for symbols such as `u_errorName_76`.
 
 Finally, you can set the following environment variables:
+
 * `EDIT_CFG_ICU_RENAMING_AUTO_DETECT`:
   If set to `true`, the executable will try to detect the `EDIT_CFG_ICU_RENAMING_VERSION` value at runtime.
   The way it does this is not officially supported by ICU and as such is not recommended to be relied upon.
   Enabled by default on UNIX (excluding macOS) if no other options are set.
 
 To test your build settings, run `cargo test` with the `--ignored` flag. For instance:
+
 ```sh
 cargo test -- --ignored
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 <!-- BEGIN MICROSOFT SECURITY.MD V0.0.9 BLOCK -->
 
-## Security
+# Security
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet) and [Xamarin](https://github.com/xamarin).
 
@@ -18,13 +18,13 @@ You should receive a response within 24 hours. If for some reason you do not, pl
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 
-  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-  * Full paths of source file(s) related to the manifestation of the issue
-  * The location of the affected source code (tag/branch/commit or direct URL)
-  * Any special configuration required to reproduce the issue
-  * Step-by-step instructions to reproduce the issue
-  * Proof-of-concept or exploit code (if possible)
-  * Impact of the issue, including how an attacker might exploit the issue
+* Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+* Full paths of source file(s) related to the manifestation of the issue
+* The location of the affected source code (tag/branch/commit or direct URL)
+* Any special configuration required to reproduce the issue
+* Step-by-step instructions to reproduce the issue
+* Proof-of-concept or exploit code (if possible)
+* Impact of the issue, including how an attacker might exploit the issue
 
 This information will help us triage your report more quickly.
 


### PR DESCRIPTION
## Summary
- Normalize Markdown spacing around lists and fenced code blocks.
- Convert README configuration tables and SECURITY list formatting to standard Markdown style.

## Validation
- git diff --check HEAD^ HEAD
