### PR TITLE
Fix zh-Hant locale fallback

### DIFF
--- a/crates/edit/src/bin/edit/localization.rs
+++ b/crates/edit/src/bin/edit/localization.rs
@@ -42,19 +42,23 @@ pub fn loc(id: LocId) -> &'static str {
 mod tests {
     use super::*;
 
-    fn assert_lang(langs: &[&str], expected: LangId) {
-        assert!(select_language(langs.iter().copied()) == expected);
-    }
-
     // Regression test for https://github.com/microsoft/edit/issues/832.
     #[test]
     fn chinese_region_aliases_select_expected_script() {
-        assert_lang(&["zh-CN.UTF-8"], LangId::zh_hans);
-        assert_lang(&["zh-SG.UTF-8"], LangId::zh_hans);
-        assert_lang(&["zh-TW.UTF-8"], LangId::zh_hant);
-        assert_lang(&["zh-HK.UTF-8"], LangId::zh_hant);
-        assert_lang(&["zh-MO.UTF-8"], LangId::zh_hant);
-        assert_lang(&["zh-Hant.UTF-8"], LangId::zh_hant);
-        assert_lang(&["zh"], LangId::zh_hans);
+        for (actual, expected) in [
+            ("zh-CN.UTF-8", "zh-hans"),
+            ("zh-SG.UTF-8", "zh-hans"),
+            ("zh-TW.UTF-8", "zh-hant"),
+            ("zh-HK.UTF-8", "zh-hant"),
+            ("zh-MO.UTF-8", "zh-hant"),
+            ("zh-Hant.UTF-8", "zh-hant"),
+            ("zh", "zh-hans"),
+        ] {
+            let Some(&(_, expected)) = LANGUAGES.iter().find(|(l, _)| expected == *l) else {
+                continue; // Disabled by EDIT_CFG_LANGUAGES
+            };
+
+            assert!(select_language(std::iter::once(actual)) == expected);
+        }
     }
 }

--- a/crates/edit/src/bin/edit/localization.rs
+++ b/crates/edit/src/bin/edit/localization.rs
@@ -12,6 +12,14 @@ static mut S_LANG: LangId = LangId::en;
 pub fn init() {
     let scratch = scratch_arena(None);
     let langs = sys::preferred_languages(&scratch);
+    let lang = select_language(langs);
+
+    unsafe {
+        S_LANG = lang;
+    }
+}
+
+fn select_language<'a>(langs: impl IntoIterator<Item = &'a str>) -> LangId {
     let mut lang = LangId::en;
 
     'outer: for l in langs {
@@ -23,11 +31,30 @@ pub fn init() {
         }
     }
 
-    unsafe {
-        S_LANG = lang;
-    }
+    lang
 }
 
 pub fn loc(id: LocId) -> &'static str {
     TRANSLATIONS[unsafe { S_LANG as usize }][id as usize]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_lang(langs: &[&str], expected: LangId) {
+        assert!(select_language(langs.iter().copied()) == expected);
+    }
+
+    // Regression test for https://github.com/microsoft/edit/issues/832.
+    #[test]
+    fn chinese_region_aliases_select_expected_script() {
+        assert_lang(&["zh-CN.UTF-8"], LangId::zh_hans);
+        assert_lang(&["zh-SG.UTF-8"], LangId::zh_hans);
+        assert_lang(&["zh-TW.UTF-8"], LangId::zh_hant);
+        assert_lang(&["zh-HK.UTF-8"], LangId::zh_hant);
+        assert_lang(&["zh-MO.UTF-8"], LangId::zh_hant);
+        assert_lang(&["zh-Hant.UTF-8"], LangId::zh_hant);
+        assert_lang(&["zh"], LangId::zh_hans);
+    }
 }

--- a/i18n/edit.toml
+++ b/i18n/edit.toml
@@ -15,6 +15,11 @@ __default__ = [
 
 [__alias__]
 sr = "sr-cyrl"
+zh-cn = "zh-hans"
+zh-hk = "zh-hant"
+zh-mo = "zh-hant"
+zh-sg = "zh-hans"
+zh-tw = "zh-hant"
 zh = "zh-hans"
 
 # The keyboard key


### PR DESCRIPTION
Region-specific Chinese locales like `zh-TW` were falling through to the broad `zh` alias, which defaults to `zh-Hans`.

This PR adds explicit Chinese region aliases so `zh-TW`, `zh-HK`, and `zh-MO` select `zh-Hant`, while `zh-CN` and `zh-SG` continue to select `zh-Hans`.

Fixes #832