### PR TITLE
Add F# highlighting

### DIFF
--- a/assets/highlighting-tests/fsharp.fsx
+++ b/assets/highlighting-tests/fsharp.fsx
@@ -1,0 +1,74 @@
+// --- F# highlighting test ---
+// Exercises: comments, block comments, strings, chars, numbers, directives,
+// keywords/control flow, types/members, and backtick identifiers.
+
+#r "System.Runtime"
+#r "nuget: Newtonsoft.Json, 13.0.3"
+#load "some-script.fsx"
+
+(*** Block comment (not nested in this highlighter) ***)
+(* Another block comment *)
+
+open System
+open Newtonsoft.Json
+
+module ``My Module With Spaces`` =
+    let pi = 3.14159
+    let hex = 0xDEAD_BEEF
+    let bin = 0b1010_1100
+    let sci = 1.23e-4
+    let mutable counter = 0
+
+    let name = "Edit"
+    let path = @"C:\Program Files\Edit\edit.exe"
+    let escaped = "tab:\t newline:\n quote:\" backslash:\\"
+    let interpolated = $"Hello, {name}!"
+    let interpolatedVerbatim = $@"Path: {path}"
+
+    let triple = """
+This is a triple-quoted string.
+It can span multiple lines without escapes.
+"""
+
+    let chA = 'a'
+    let chN = '\n'
+
+    let rec fib n =
+        if n <= 1 then n
+        else fib (n - 1) + fib (n - 2)
+
+    let classify x =
+        match x with
+        | 0 -> "zero"
+        | 1 | 2 -> "small"
+        | _ when x < 0 -> "negative"
+        | _ -> "other"
+
+    let tryParseInt (s: string) =
+        try
+            let v = Int32.Parse(s)
+            Ok v
+        with
+        | :? FormatException -> Error "format"
+        | ex -> Error ex.Message
+
+    type Person(name: string, age: int) =
+        member _.Name = name
+        member _.Age = age
+        override _.ToString() = $"{name} ({age})"
+
+    let demoLoops () =
+        for i = 1 to 3 do
+            counter <- counter + i
+
+        while counter < 20 do
+            counter <- counter + 1
+
+        // Method-call style tokenization
+        let p = Person("Ada", 37)
+        printfn "%s" (p.ToString())
+
+    // Single-backtick identifier fallback (not typical F#, but supported by lexer)
+    let `singleBacktickIdentifier` = 42
+
+    demoLoops ()

--- a/assets/highlighting-tests/fsharp.fsx
+++ b/assets/highlighting-tests/fsharp.fsx
@@ -1,74 +1,144 @@
-// --- F# highlighting test ---
-// Exercises: comments, block comments, strings, chars, numbers, directives,
-// keywords/control flow, types/members, and backtick identifiers.
+// Single-line comment
+/// Documentation comment
+(* Block comment
+   spanning multiple lines *)
+(*** Banner comment ***)
 
-#r "System.Runtime"
 #r "nuget: Newtonsoft.Json, 13.0.3"
 #load "some-script.fsx"
+#I "lib"
+#nowarn "40"
+#if DEBUG
+#light
+#endif
 
-(*** Block comment (not nested in this highlighter) ***)
-(* Another block comment *)
+module Demo.App
 
 open System
-open Newtonsoft.Json
 
-module ``My Module With Spaces`` =
-    let pi = 3.14159
-    let hex = 0xDEAD_BEEF
-    let bin = 0b1010_1100
-    let sci = 1.23e-4
+// Numbers
+42
+3.14
+.5
+10_000_000
+1e10
+1.5e-3
+0xff
+0xFF
+0b1010
+0o777
+42y
+42uy
+42s
+42us
+42L
+42UL
+42n
+42un
+42I
+3.14f
+3.14m
+3.14M
+-.5_0_1e3_0
+
+// Constants
+true
+false
+null
+
+// Strings and characters
+'a'
+'\n'
+'\\'
+'\''
+"double quotes with escape: \" \n \t \\"
+$"interpolated {1 + 1}"
+@"C:\Temp\file.txt"
+@"verbatim with ""escaped"" quotes"
+$@"interpolated verbatim {1}"
+"""
+triple-quoted string
+"""
+$"""interpolated triple-quoted {1}"""
+
+// Backtick identifiers
+let ``an identifier with spaces`` = 1
+
+[<Obsolete("Use NewThing instead")>]
+type Person(name: string, age: int) =
+    member val Nickname = "" with get, set
+    member _.Name: string = name
+    member _.Age: int = age
+    override _.ToString() = $"{name} ({age})"
+
+[<AbstractClass>]
+type Shape() =
+    abstract member Area: unit -> float
+    default _.Area() = 0.0
+
+type Color =
+    | Red
+    | Green
+    | Blue
+
+type IGreeter =
+    abstract member Greet: string -> unit
+
+// Generic type parameters must not be mistaken for character literals
+let swap (a: 'a, b: 'b) = (b, a)
+let inline add (x: ^T) (y: ^T) = x + y
+
+let rec fib n =
+    if n <= 1 then n
+    else fib (n - 1) + fib (n - 2)
+
+let classify x =
+    match x with
+    | 0 -> "zero"
+    | 1 | 2 -> "small"
+    | _ when x < 0 -> "negative"
+    | _ -> "other"
+
+let tryParseInt (s: string) =
+    try
+        let v = Int32.Parse(s)
+        Ok v
+    with
+    | :? FormatException -> Error "format"
+    | ex -> Error ex.Message
+
+let demoLoops () =
     let mutable counter = 0
 
-    let name = "Edit"
-    let path = @"C:\Program Files\Edit\edit.exe"
-    let escaped = "tab:\t newline:\n quote:\" backslash:\\"
-    let interpolated = $"Hello, {name}!"
-    let interpolatedVerbatim = $@"Path: {path}"
+    for i = 1 to 3 do
+        counter <- counter + i
 
-    let triple = """
-This is a triple-quoted string.
-It can span multiple lines without escapes.
-"""
+    for i = 3 downto 1 do
+        counter <- counter - i
 
-    let chA = 'a'
-    let chN = '\n'
+    while counter < 20 do
+        counter <- counter + 1
 
-    let rec fib n =
-        if n <= 1 then n
-        else fib (n - 1) + fib (n - 2)
+    counter
 
-    let classify x =
-        match x with
-        | 0 -> "zero"
-        | 1 | 2 -> "small"
-        | _ when x < 0 -> "negative"
-        | _ -> "other"
+let demoLambdas () =
+    let twice = fun x -> x * 2
+    let thrice = function x -> x * 3
+    [ 1; 2; 3 ] |> List.map twice |> List.map thrice
 
-    let tryParseInt (s: string) =
-        try
-            let v = Int32.Parse(s)
-            Ok v
-        with
-        | :? FormatException -> Error "format"
-        | ex -> Error ex.Message
+let demoResources () =
+    use stream = new IO.MemoryStream()
+    assert (stream.Length = 0L)
+    lazy (stream.Length)
 
-    type Person(name: string, age: int) =
-        member _.Name = name
-        member _.Age = age
-        override _.ToString() = $"{name} ({age})"
+exception MyError of string
 
-    let demoLoops () =
-        for i = 1 to 3 do
-            counter <- counter + i
+module private Internals =
+    let helper () = raise (MyError "boom")
 
-        while counter < 20 do
-            counter <- counter + 1
-
-        // Method-call style tokenization
-        let p = Person("Ada", 37)
-        printfn "%s" (p.ToString())
-
-    // Single-backtick identifier fallback (not typical F#, but supported by lexer)
-    let `singleBacktickIdentifier` = 42
-
-    demoLoops ()
+[<EntryPoint>]
+let main argv =
+    printfn "%s" (Person("Ada", 37).ToString())
+    demoLoops () |> ignore
+    demoLambdas () |> ignore
+    0

--- a/crates/lsh/definitions/fsharp.lsh
+++ b/crates/lsh/definitions/fsharp.lsh
@@ -1,0 +1,115 @@
+#[display_name = "F#"]
+#[path = "**/*.fs"]
+#[path = "**/*.fsi"]
+#[path = "**/*.fsx"]
+pub fn fsharp() {
+    until /$/ {
+        yield other;
+
+        // Line comment
+        if /\/\/.*/ {
+            yield comment;
+
+        // Preprocessor / script directives
+        } else if /#(?:if|else|endif|load|r|I|nowarn|light|time|help|quit)\>.*/ {
+            yield keyword.other;
+
+        // Block comment: (* ... *)
+        } else if /\(\*/ {
+            loop {
+                yield comment;
+                if /\*\)/ {
+                    yield comment;
+                    break;
+                }
+                await input;
+            }
+
+        // Triple-quoted string: """ ... """
+        } else if /"""/ {
+            loop {
+                yield string;
+                if /"""/ {
+                    yield string;
+                    break;
+                }
+                await input;
+            }
+
+        // Verbatim (optionally interpolated) string: @"..." or $@"..."
+        } else if /\$?@"/ {
+            loop {
+                yield string;
+                if /""/ {
+                    // Escaped quote
+                } else if /"/ {
+                    yield string;
+                    break;
+                }
+                await input;
+            }
+
+        // Interpolated string: $"..."
+        } else if /\$"/ {
+            until /$/ {
+                yield string;
+                if /\\./ {
+                    // Escape sequences
+                } else if /"/ {
+                    yield string;
+                    break;
+                }
+                await input;
+            }
+
+        // Regular string: "..."
+        } else if /"/ {
+            until /$/ {
+                yield string;
+                if /\\./ {
+                    // Escape sequences
+                } else if /"/ {
+                    yield string;
+                    break;
+                }
+                await input;
+            }
+
+        // Character literal: 'a', '\n', etc.
+        } else if /'(?:\\.|[^'\\])'/ {
+            yield string;
+
+        // Backtick identifiers: ``identifier with spaces``
+        } else if /``[^`]+``/ {
+            yield variable;
+        } else if /`[^`]+`/ {
+            yield variable;
+
+        // Keywords
+        } else if /(?:if|then|else|elif|match|with|function|try|finally|for|to|downto|while|do|return|yield|begin|end|in)\>/ {
+            yield keyword.control;
+        } else if /(?:let|use|and|rec|mutable|open|module|namespace|type|member|interface|abstract|override|default|static|inline|extern|public|private|internal|new|inherit|as|of|when|exception|raise|lazy|assert|global)\>/ {
+            yield keyword.other;
+
+        // Language constants
+        } else if /(?:true|false|null)\>/ {
+            yield constant.language;
+
+        // Numbers (best-effort)
+        } else if /(?i:-?(?:0x[\da-f_]+|0b[01_]+|0o[0-7_]+|[\d_]+\.?[\d_]*|\.[\d_]+)(?:e[+-]?[\d_]+)?)(?:u(?:y|s|l|n)|(?:y|s|l|n)|[fFmM])?/ {
+            if /\w+/ {
+                // Not a number after all.
+            } else {
+                yield constant.numeric;
+            }
+
+        // Method calls in .NET-style syntax: Foo.Bar(...)
+        } else if /(\w+)\s*\(/ {
+            yield $1 as method;
+        } else if /\w+/ {
+            // Gobble word chars to align the next iteration on a word boundary.
+        }
+
+        yield other;
+    }
+}

--- a/crates/lsh/definitions/fsharp.lsh
+++ b/crates/lsh/definitions/fsharp.lsh
@@ -3,30 +3,29 @@
 #[path = "**/*.fsi"]
 #[path = "**/*.fsx"]
 pub fn fsharp() {
+    // Compiler and script directives always occupy the entire line.
+    if /\s*#(?:if|else|endif|light|line|load|nowarn|time|help|quit|r|I)\>.*/ {
+        yield keyword.preprocessor;
+        return;
+    }
+
     until /$/ {
         yield other;
 
-        // Line comment
         if /\/\/.*/ {
             yield comment;
-
-        // Preprocessor / script directives
-        } else if /#(?:if|else|endif|load|r|I|nowarn|light|time|help|quit)\>.*/ {
-            yield keyword.other;
-
-        // Block comment: (* ... *)
         } else if /\(\*/ {
+            // F# block comments nest, but LSH can't count, so we stop at the first `*)`.
             loop {
                 yield comment;
+                await input;
                 if /\*\)/ {
                     yield comment;
                     break;
                 }
-                await input;
             }
-
-        // Triple-quoted string: """ ... """
-        } else if /"""/ {
+        } else if /\$*"""/ {
+            // Triple-quoted string. It has no escape sequences and may span lines.
             loop {
                 yield string;
                 if /"""/ {
@@ -35,9 +34,8 @@ pub fn fsharp() {
                 }
                 await input;
             }
-
-        // Verbatim (optionally interpolated) string: @"..." or $@"..."
         } else if /\$?@"/ {
+            // Verbatim string. `""` is the only escape sequence and it may span lines.
             loop {
                 yield string;
                 if /""/ {
@@ -48,62 +46,30 @@ pub fn fsharp() {
                 }
                 await input;
             }
-
-        // Interpolated string: $"..."
-        } else if /\$"/ {
-            until /$/ {
-                yield string;
-                if /\\./ {
-                    // Escape sequences
-                } else if /"/ {
-                    yield string;
-                    break;
-                }
-                await input;
-            }
-
-        // Regular string: "..."
-        } else if /"/ {
-            until /$/ {
-                yield string;
-                if /\\./ {
-                    // Escape sequences
-                } else if /"/ {
-                    yield string;
-                    break;
-                }
-                await input;
-            }
-
-        // Character literal: 'a', '\n', etc.
-        } else if /'(?:\\.|[^'\\])'/ {
+        } else if /\$?"/ {
+            double_quote_string();
+        } else if /'\\?.'/ {
+            // A lone `'` starts a generic type parameter, so a character literal
+            // must only match if the closing quote is present as well.
             yield string;
-
-        // Backtick identifiers: ``identifier with spaces``
         } else if /``[^`]+``/ {
             yield variable;
-        } else if /`[^`]+`/ {
-            yield variable;
-
-        // Keywords
-        } else if /(?:if|then|else|elif|match|with|function|try|finally|for|to|downto|while|do|return|yield|begin|end|in)\>/ {
+        } else if /\[<([A-Z]\w*)/ {
+            yield $1 as storage.annotation;
+        } else if /(?:if|then|elif|else|match|with|function|fun|try|finally|for|downto|done|do|to|while|return|yield|begin|end|in)\>/ {
             yield keyword.control;
-        } else if /(?:let|use|and|rec|mutable|open|module|namespace|type|member|interface|abstract|override|default|static|inline|extern|public|private|internal|new|inherit|as|of|when|exception|raise|lazy|assert|global)\>/ {
+        } else if /(?:abstract|and|assert|as|base|class|default|delegate|downcast|enum|exception|extern|global|inherit|inline|interface|internal|lazy|let|member|module|mutable|namespace|new|not|of|open|or|override|private|protected|public|rec|sig|static|struct|type|upcast|use|val|when)\>/ {
             yield keyword.other;
-
-        // Language constants
         } else if /(?:true|false|null)\>/ {
             yield constant.language;
-
-        // Numbers (best-effort)
-        } else if /(?i:-?(?:0x[\da-f_]+|0b[01_]+|0o[0-7_]+|[\d_]+\.?[\d_]*|\.[\d_]+)(?:e[+-]?[\d_]+)?)(?:u(?:y|s|l|n)|(?:y|s|l|n)|[fFmM])?/ {
+        } else if /(?:bigint|bool|byte|char|decimal|double|exn|float32|float|int8|int16|int32|int64|int|nativeint|obj|sbyte|single|string|uint8|uint16|uint32|uint64|unativeint|uint|unit|void)\>/ {
+            yield storage.type;
+        } else if /(?i:-?(?:0x[\da-f_]+|0b[01_]+|0o[0-7_]+|[\d_]+\.?[\d_]*|\.[\d_]+)(?:e[+-]?[\d_]+)?[filmnsuy]{0,2})/ {
             if /\w+/ {
-                // Not a number after all.
+                // Invalid numeric literal
             } else {
                 yield constant.numeric;
             }
-
-        // Method calls in .NET-style syntax: Foo.Bar(...)
         } else if /(\w+)\s*\(/ {
             yield $1 as method;
         } else if /\w+/ {


### PR DESCRIPTION
This pull request introduces F# language support to the syntax highlighting system. It adds a comprehensive F# lexer definition and a corresponding test file to ensure proper highlighting of F# language features.

**F# Language Highlighting Support:**

* Added a new F# lexer definition in `fsharp.lsh`, supporting comments, directives, strings (including verbatim, interpolated, and triple-quoted), character literals, keywords, numbers, and backtick identifiers.
* Introduced a highlighting test file `fsharp.fsx` that exercises a wide range of F# syntax constructs to validate the new lexer.

<details><summary>Screenshot</summary>

<img width="809" height="683" alt="image" src="https://github.com/user-attachments/assets/77f30a3f-e0fe-4e99-a8db-7fb26f72b2cc" />

</details> 