### PR TITLE
Isolate startup probe parser and drain responses

### DIFF
--- a/crates/edit/src/bin/edit/main.rs
+++ b/crates/edit/src/bin/edit/main.rs
@@ -658,6 +658,74 @@ impl TerminalProbe {
     }
 }
 
+fn record_probe_osc_response(
+    osc_buffer: &mut String,
+    indexed_colors: &mut [StraightRgba; framebuffer::INDEXED_COLORS_COUNT],
+    probe: &mut TerminalProbe,
+    data: &str,
+    partial: bool,
+) {
+    if partial {
+        osc_buffer.push_str(data);
+        return;
+    }
+
+    let parsed = if osc_buffer.is_empty() {
+        parse_probe_color_response(data)
+    } else {
+        osc_buffer.push_str(data);
+        parse_probe_color_response(osc_buffer)
+    };
+
+    if let Some((color_index, color)) = parsed {
+        indexed_colors[color_index] = color;
+        probe.record_color(color_index);
+    }
+
+    osc_buffer.clear();
+}
+
+fn parse_probe_color_response(data: &str) -> Option<(usize, StraightRgba)> {
+    let mut splits = data.split_terminator(';');
+
+    let color_index = match splits.next().unwrap_or("") {
+        // The response is `4;<color>;rgb:<r>/<g>/<b>`.
+        "4" => match splits.next().unwrap_or("").parse::<usize>() {
+            Ok(val) if val < 16 => val,
+            _ => return None,
+        },
+        // The response is `10;rgb:<r>/<g>/<b>`.
+        "10" => IndexedColor::Foreground as usize,
+        // The response is `11;rgb:<r>/<g>/<b>`.
+        "11" => IndexedColor::Background as usize,
+        _ => return None,
+    };
+
+    let color_param = splits.next().unwrap_or("");
+    if !color_param.starts_with("rgb:") {
+        return None;
+    }
+
+    let mut iter = color_param[4..].split_terminator('/');
+    let rgb_parts = [(); 3].map(|_| iter.next().unwrap_or("0"));
+    let mut rgb = 0;
+
+    for part in rgb_parts {
+        if part.len() == 2 || part.len() == 4 {
+            let Ok(mut val) = usize::from_str_radix(part, 16) else {
+                continue;
+            };
+            if part.len() == 4 {
+                // Round from 16 bits to 8 bits.
+                val = (val * 0xff + 0x7fff) / 0xffff;
+            }
+            rgb = (rgb >> 8) | ((val as u32) << 16);
+        }
+    }
+
+    Some((color_index, StraightRgba::from_le(rgb | 0xff000000)))
+}
+
 fn setup_terminal(tui: &mut Tui, state: &mut State) -> RestoreModes {
     sys::write_stdout(concat!(
         // 1049: Alternative Screen Buffer
@@ -726,57 +794,15 @@ fn setup_terminal(tui: &mut Tui, state: &mut State) -> RestoreModes {
                     }
                     _ => {}
                 },
-                Token::Osc { mut data, partial } => {
+                Token::Osc { data, partial } => {
                     probe_activity = true;
-                    if partial {
-                        osc_buffer.push_str(data);
-                        continue;
-                    }
-                    if !osc_buffer.is_empty() {
-                        osc_buffer.push_str(data);
-                        data = &osc_buffer;
-                    }
-
-                    let mut splits = data.split_terminator(';');
-
-                    let color_index = match splits.next().unwrap_or("") {
-                        // The response is `4;<color>;rgb:<r>/<g>/<b>`.
-                        "4" => match splits.next().unwrap_or("").parse::<usize>() {
-                            Ok(val) if val < 16 => val,
-                            _ => continue,
-                        },
-                        // The response is `10;rgb:<r>/<g>/<b>`.
-                        "10" => IndexedColor::Foreground as usize,
-                        // The response is `11;rgb:<r>/<g>/<b>`.
-                        "11" => IndexedColor::Background as usize,
-                        _ => continue,
-                    };
-
-                    let color_param = splits.next().unwrap_or("");
-                    if !color_param.starts_with("rgb:") {
-                        continue;
-                    }
-
-                    let mut iter = color_param[4..].split_terminator('/');
-                    let rgb_parts = [(); 3].map(|_| iter.next().unwrap_or("0"));
-                    let mut rgb = 0;
-
-                    for part in rgb_parts {
-                        if part.len() == 2 || part.len() == 4 {
-                            let Ok(mut val) = usize::from_str_radix(part, 16) else {
-                                continue;
-                            };
-                            if part.len() == 4 {
-                                // Round from 16 bits to 8 bits.
-                                val = (val * 0xff + 0x7fff) / 0xffff;
-                            }
-                            rgb = (rgb >> 8) | ((val as u32) << 16);
-                        }
-                    }
-
-                    indexed_colors[color_index] = StraightRgba::from_le(rgb | 0xff000000);
-                    probe.record_color(color_index);
-                    osc_buffer.clear();
+                    record_probe_osc_response(
+                        &mut osc_buffer,
+                        &mut indexed_colors,
+                        &mut probe,
+                        data,
+                        partial,
+                    );
                 }
                 Token::Dcs { .. } => probe_activity = true,
                 _ => {}
@@ -874,5 +900,38 @@ mod terminal_probe_tests {
         probe.record_color(IndexedColor::Background as usize);
 
         assert_eq!(probe.color_responses(), 2);
+    }
+
+    #[test]
+    fn probe_osc_buffer_clears_after_invalid_complete_response() {
+        let mut osc_buffer = String::new();
+        let mut indexed_colors = framebuffer::DEFAULT_THEME;
+        let mut probe = TerminalProbe::new();
+
+        record_probe_osc_response(
+            &mut osc_buffer,
+            &mut indexed_colors,
+            &mut probe,
+            "99;ignored",
+            true,
+        );
+        assert!(!osc_buffer.is_empty());
+
+        record_probe_osc_response(&mut osc_buffer, &mut indexed_colors, &mut probe, "", false);
+        assert!(osc_buffer.is_empty());
+
+        record_probe_osc_response(
+            &mut osc_buffer,
+            &mut indexed_colors,
+            &mut probe,
+            "10;rgb:0101/0202/0303",
+            false,
+        );
+
+        assert_eq!(probe.color_responses(), 1);
+        assert_ne!(
+            indexed_colors[IndexedColor::Foreground as usize],
+            framebuffer::DEFAULT_THEME[IndexedColor::Foreground as usize]
+        );
     }
 }

--- a/crates/edit/src/bin/edit/main.rs
+++ b/crates/edit/src/bin/edit/main.rs
@@ -40,6 +40,12 @@ const SCRATCH_ARENA_CAPACITY: usize = 128 * MEBI;
 #[cfg(target_pointer_width = "64")]
 const SCRATCH_ARENA_CAPACITY: usize = 512 * MEBI;
 
+// After DA, briefly drain follow-up probe responses so split OSC replies do not leak into
+// the main input parser. Keep the window short because real user input is still on stdin.
+const TERMINAL_PROBE_QUIET_TIMEOUT: Duration = Duration::from_millis(50);
+// Bound terminal probing for terminals that omit DA or leave a control sequence unfinished.
+const TERMINAL_PROBE_HARD_TIMEOUT: Duration = Duration::from_secs(3);
+
 // NOTE: Before our main() gets called, Rust initializes its stdlib. This pulls in the entire
 // std::io::{stdin, stdout, stderr} machinery, and probably some more, which amounts to about 20KB.
 // It can technically be avoided nowadays with `#![no_main]`. Maybe a fun project for later? :)
@@ -87,11 +93,9 @@ fn run() -> apperr::Result<()> {
     // As such, we call this after `handle_args`.
     sys::switch_modes()?;
 
-    let mut vt_parser = vt::Parser::new();
-    let mut input_parser = input::Parser::new();
     let mut tui = Tui::new()?;
 
-    let _restore = setup_terminal(&mut tui, &mut state, &mut vt_parser);
+    let _restore = setup_terminal(&mut tui, &mut state);
 
     state.menubar_color_bg = tui.indexed(IndexedColor::Background).oklab_blend(tui.indexed_alpha(
         IndexedColor::BrightBlue,
@@ -114,6 +118,11 @@ fn run() -> apperr::Result<()> {
     tui.set_modal_default_fg(floater_fg);
 
     sys::inject_window_size_into_stdin();
+
+    // Startup probing may leave partial terminal responses in the probe parser.
+    // Start application input parsing with an independent parser lifecycle.
+    let mut vt_parser = vt::Parser::new();
+    let mut input_parser = input::Parser::new();
 
     #[cfg(feature = "debug-latency")]
     let mut last_latency_width = 0;
@@ -565,7 +574,91 @@ impl Drop for RestoreModes {
     }
 }
 
-fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) -> RestoreModes {
+struct TerminalProbe {
+    seen_device_attributes: bool,
+    seen_cursor_position: bool,
+    seen_colors: [bool; framebuffer::INDEXED_COLORS_COUNT],
+    color_responses: usize,
+    quiet_deadline: Option<std::time::Instant>,
+}
+
+impl TerminalProbe {
+    fn new() -> Self {
+        Self {
+            seen_device_attributes: false,
+            seen_cursor_position: false,
+            seen_colors: [false; framebuffer::INDEXED_COLORS_COUNT],
+            color_responses: 0,
+            quiet_deadline: None,
+        }
+    }
+
+    fn record_device_attributes(&mut self, now: std::time::Instant) {
+        self.seen_device_attributes = true;
+        self.quiet_deadline = Some(now + TERMINAL_PROBE_QUIET_TIMEOUT);
+    }
+
+    fn record_activity_after_device_attributes(&mut self, now: std::time::Instant) {
+        if self.seen_device_attributes {
+            self.quiet_deadline = Some(now + TERMINAL_PROBE_QUIET_TIMEOUT);
+        }
+    }
+
+    fn record_cursor_position(&mut self) {
+        self.seen_cursor_position = true;
+    }
+
+    fn record_color(&mut self, index: usize) {
+        if !self.seen_colors[index] {
+            self.seen_colors[index] = true;
+            self.color_responses += 1;
+        }
+    }
+
+    fn color_responses(&self) -> usize {
+        self.color_responses
+    }
+
+    fn is_complete(&self) -> bool {
+        self.seen_device_attributes
+            && self.seen_cursor_position
+            && self.color_responses == framebuffer::INDEXED_COLORS_COUNT
+    }
+
+    fn should_finish(
+        &self,
+        parser_is_ground: bool,
+        now: std::time::Instant,
+        hard_deadline: std::time::Instant,
+    ) -> bool {
+        if parser_is_ground && self.is_complete() {
+            return true;
+        }
+
+        if parser_is_ground
+            && self.seen_device_attributes
+            && self.quiet_deadline.is_some_and(|deadline| now >= deadline)
+        {
+            return true;
+        }
+
+        now >= hard_deadline
+    }
+
+    fn next_read_deadline(
+        &self,
+        parser_is_ground: bool,
+        hard_deadline: std::time::Instant,
+    ) -> std::time::Instant {
+        if parser_is_ground {
+            self.quiet_deadline.unwrap_or(hard_deadline).min(hard_deadline)
+        } else {
+            hard_deadline
+        }
+    }
+}
+
+fn setup_terminal(tui: &mut Tui, state: &mut State) -> RestoreModes {
     sys::write_stdout(concat!(
         // 1049: Alternative Screen Buffer
         //   I put the ASB switch in the beginning, just in case the terminal performs
@@ -592,32 +685,49 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
         "\x1b[c",
     ));
 
-    let mut done = false;
     let mut osc_buffer = String::new();
     let mut indexed_colors = framebuffer::DEFAULT_THEME;
-    let mut color_responses = 0;
     let mut ambiguous_width = 1;
+    let mut probe = TerminalProbe::new();
+    let mut vt_parser = vt::Parser::new();
+    let hard_deadline = std::time::Instant::now() + TERMINAL_PROBE_HARD_TIMEOUT;
 
-    while !done {
+    loop {
+        let now = std::time::Instant::now();
+        if probe.should_finish(vt_parser.is_ground(), now, hard_deadline) {
+            break;
+        }
+
         let scratch = scratch_arena(None);
+        let mut timeout = probe
+            .next_read_deadline(vt_parser.is_ground(), hard_deadline)
+            .saturating_duration_since(now);
+        timeout = timeout.min(vt_parser.read_timeout());
 
-        // We explicitly set a high read timeout, because we're not
-        // waiting for user keyboard input. If we encounter a lone ESC,
-        // it's unlikely to be from a ESC keypress, but rather from a VT sequence.
-        let Some(input) = sys::read_stdin(&scratch, Duration::from_secs(3)) else {
+        let Some(input) = sys::read_stdin(&scratch, timeout) else {
             break;
         };
 
+        let got_input = !input.is_empty();
+        let mut probe_activity = false;
         let mut vt_stream = vt_parser.parse(&input);
         while let Some(token) = vt_stream.next() {
             match token {
                 Token::Csi(csi) => match csi.final_byte {
-                    'c' => done = true,
+                    'c' => {
+                        probe.record_device_attributes(std::time::Instant::now());
+                        probe_activity = true;
+                    }
                     // CPR (Cursor Position Report) response.
-                    'R' => ambiguous_width = csi.params[1] as CoordType - 1,
+                    'R' => {
+                        probe.record_cursor_position();
+                        ambiguous_width = csi.params[1] as CoordType - 1;
+                        probe_activity = true;
+                    }
                     _ => {}
                 },
                 Token::Osc { mut data, partial } => {
+                    probe_activity = true;
                     if partial {
                         osc_buffer.push_str(data);
                         continue;
@@ -629,16 +739,16 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
 
                     let mut splits = data.split_terminator(';');
 
-                    let color = match splits.next().unwrap_or("") {
+                    let color_index = match splits.next().unwrap_or("") {
                         // The response is `4;<color>;rgb:<r>/<g>/<b>`.
                         "4" => match splits.next().unwrap_or("").parse::<usize>() {
-                            Ok(val) if val < 16 => &mut indexed_colors[val],
+                            Ok(val) if val < 16 => val,
                             _ => continue,
                         },
                         // The response is `10;rgb:<r>/<g>/<b>`.
-                        "10" => &mut indexed_colors[IndexedColor::Foreground as usize],
+                        "10" => IndexedColor::Foreground as usize,
                         // The response is `11;rgb:<r>/<g>/<b>`.
-                        "11" => &mut indexed_colors[IndexedColor::Background as usize],
+                        "11" => IndexedColor::Background as usize,
                         _ => continue,
                     };
 
@@ -664,12 +774,17 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
                         }
                     }
 
-                    *color = StraightRgba::from_le(rgb | 0xff000000);
-                    color_responses += 1;
+                    indexed_colors[color_index] = StraightRgba::from_le(rgb | 0xff000000);
+                    probe.record_color(color_index);
                     osc_buffer.clear();
                 }
+                Token::Dcs { .. } => probe_activity = true,
                 _ => {}
             }
+        }
+
+        if probe_activity || got_input && !vt_parser.is_ground() {
+            probe.record_activity_after_device_attributes(std::time::Instant::now());
         }
     }
 
@@ -678,7 +793,7 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
         state.documents.reflow_all();
     }
 
-    if color_responses == indexed_colors.len() {
+    if probe.color_responses() == indexed_colors.len() {
         tui.setup_indexed_colors(indexed_colors);
     }
 
@@ -702,5 +817,62 @@ fn sanitize_control_chars(text: &str) -> Cow<'_, str> {
         Cow::Owned(sanitized)
     } else {
         Cow::Borrowed(text)
+    }
+}
+
+#[cfg(test)]
+mod terminal_probe_tests {
+    use super::*;
+
+    #[test]
+    fn probe_waits_past_quiet_window_when_parser_has_pending_sequence() {
+        let start = std::time::Instant::now();
+        let hard_deadline = start + TERMINAL_PROBE_HARD_TIMEOUT;
+        let mut probe = TerminalProbe::new();
+
+        probe.record_device_attributes(start);
+        let quiet_deadline = start + TERMINAL_PROBE_QUIET_TIMEOUT;
+
+        assert!(!probe.should_finish(false, quiet_deadline, hard_deadline));
+        assert!(probe.should_finish(false, hard_deadline, hard_deadline));
+    }
+
+    #[test]
+    fn probe_finishes_after_quiet_window_when_parser_is_ground() {
+        let start = std::time::Instant::now();
+        let hard_deadline = start + TERMINAL_PROBE_HARD_TIMEOUT;
+        let mut probe = TerminalProbe::new();
+
+        probe.record_device_attributes(start);
+        let quiet_deadline = start + TERMINAL_PROBE_QUIET_TIMEOUT;
+
+        assert!(probe.should_finish(true, quiet_deadline, hard_deadline));
+    }
+
+    #[test]
+    fn probe_complete_fast_path_requires_ground_parser() {
+        let start = std::time::Instant::now();
+        let hard_deadline = start + TERMINAL_PROBE_HARD_TIMEOUT;
+        let mut probe = TerminalProbe::new();
+
+        probe.record_device_attributes(start);
+        probe.record_cursor_position();
+        for index in 0..framebuffer::INDEXED_COLORS_COUNT {
+            probe.record_color(index);
+        }
+
+        assert!(!probe.should_finish(false, start, hard_deadline));
+        assert!(probe.should_finish(true, start, hard_deadline));
+    }
+
+    #[test]
+    fn probe_counts_unique_color_responses() {
+        let mut probe = TerminalProbe::new();
+
+        probe.record_color(IndexedColor::Foreground as usize);
+        probe.record_color(IndexedColor::Foreground as usize);
+        probe.record_color(IndexedColor::Background as usize);
+
+        assert_eq!(probe.color_responses(), 2);
     }
 }

--- a/crates/edit/src/input.rs
+++ b/crates/edit/src/input.rs
@@ -592,3 +592,42 @@ impl<'input> Stream<'_, '_, 'input> {
         Some(Input::Mouse(mouse))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_resize<'a>(
+        vt_parser: &mut vt::Parser,
+        input_parser: &mut Parser,
+        input: &'a str,
+    ) -> Option<Size> {
+        input_parser.parse(vt_parser.parse(input)).find_map(|input| match input {
+            Input::Resize(size) => Some(size),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn partial_osc_parser_state_does_not_emit_resize() {
+        let mut vt_parser = vt::Parser::new();
+        let mut stream = vt_parser.parse("\x1b]4;0;rgb:0c0c/0c0c/0c0c\x1b");
+        while stream.next().is_some() {}
+        drop(stream);
+
+        let mut input_parser = Parser::new();
+        let resize = parse_resize(&mut vt_parser, &mut input_parser, "\x1b[8;40;127t");
+
+        assert_eq!(resize, None);
+    }
+
+    #[test]
+    fn fresh_parser_parses_synthetic_resize() {
+        let mut vt_parser = vt::Parser::new();
+        let mut input_parser = Parser::new();
+
+        let resize = parse_resize(&mut vt_parser, &mut input_parser, "\x1b[8;40;127t");
+
+        assert_eq!(resize, Some(Size { width: 127, height: 40 }));
+    }
+}

--- a/crates/edit/src/vt.rs
+++ b/crates/edit/src/vt.rs
@@ -80,6 +80,11 @@ impl Parser {
         }
     }
 
+    /// Returns whether the parser has no unfinished VT sequence pending.
+    pub fn is_ground(&self) -> bool {
+        matches!(self.state, State::Ground)
+    }
+
     /// Suggests a timeout for the next call to `read()`.
     ///
     /// We need this because of the ambiguity of whether a trailing
@@ -116,6 +121,45 @@ pub struct Stream<'parser, 'input> {
     parser: &'parser mut Parser,
     input: &'input str,
     off: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parser_reports_pending_osc_until_st_is_complete() {
+        let mut parser = Parser::new();
+        assert!(parser.is_ground());
+
+        let mut stream = parser.parse("\x1b]11;rgb:0c0c/0c0c/0c0c\x1b");
+        assert!(stream.next().is_some());
+        assert!(stream.next().is_none());
+        drop(stream);
+        assert!(!parser.is_ground());
+
+        let mut stream = parser.parse("\\");
+        assert!(matches!(stream.next(), Some(Token::Osc { partial: false, .. })));
+        assert!(stream.next().is_none());
+        drop(stream);
+        assert!(parser.is_ground());
+    }
+
+    #[test]
+    fn parser_reports_ground_after_escape_timeout() {
+        let mut parser = Parser::new();
+
+        let mut stream = parser.parse("\x1b");
+        assert!(stream.next().is_none());
+        drop(stream);
+        assert!(!parser.is_ground());
+
+        let mut stream = parser.parse("");
+        assert!(matches!(stream.next(), Some(Token::Esc('\0'))));
+        assert!(stream.next().is_none());
+        drop(stream);
+        assert!(parser.is_ground());
+    }
 }
 
 impl<'input> Stream<'_, 'input> {


### PR DESCRIPTION
## Summary

This isolates the VT parser used for terminal startup probing from the VT parser used by the main input loop, and adds a bounded post-DA drain for startup probe responses.

`setup_terminal()` now owns a local `vt::Parser`, drains follow-up probe responses for a short quiet window after DA, and `run()` creates the application input parser only after startup probing has completed. This prevents parser state left by startup probing from consuming subsequent application input, including the Unix synthetic resize sequence, while also reducing the chance that a split OSC color response tail is parsed as editor text.

Fixes #868.

Reported and reproduced by @tyx3211. Analysis/write-up assisted by Codex.

## Root cause

Before this change, startup probing and application input shared the same `vt::Parser` instance:

1. `setup_terminal()` read OSC color replies, CPR, and DA through the main parser.
2. It treated a DA response whose CSI final byte is `c` as the end marker for startup responses.
3. In the captured failure, another OSC color response began after DA and the read ended with a partial OSC/ST sequence.
4. The main loop then reused that parser while it was still in `OscEsc`/`Osc`.
5. On Unix, the synthetic resize (`ESC[8;rows;cols t`) was parsed as OSC payload instead of `Input::Resize`.
6. `Tui` stayed at `Size { width: 0, height: 0 }`, and the first render panicked in `chunks_exact(0)`.

This does not require the terminal to emit an invalid VT sequence. DA is a response token, not a transaction boundary for all earlier startup queries. A legal byte stream may contain DA followed by a later ST-terminated OSC response, and the OS/PTY `read()` boundary may split that OSC terminator between `ESC` and `\`. The fix therefore treats DA as the start of a bounded wind-down phase rather than proof that startup probing is complete.

## Changes

- Move creation of the main-loop `vt::Parser` and `input::Parser` until after `setup_terminal()`.
- Change `setup_terminal()` so it creates and owns its own probe `vt::Parser`.
- Add a bounded probe drain after DA: finish immediately when the useful probe results are complete and the parser is back at ground, finish after a short quiet window when DA has arrived and the parser is back at ground, or stop at a hard deadline.
- Expose `vt::Parser::is_ground()` so startup probing can avoid discarding a probe parser while it is still inside an unfinished VT sequence.
- Count unique color response indices before applying the probed palette.
- Clear the probe OSC buffer after every complete OSC response, including unrecognized or malformed responses, so a stale partial response cannot pollute later color replies.
- Add parser behavior tests documenting that a partial OSC parser state does not emit the synthetic resize, while a fresh parser parses the same bytes as `Input::Resize`.
- Add probe-state tests for the fast path, quiet-window path, pending-sequence wait, unique color counting, and OSC buffer cleanup after an invalid complete response.

## Probe drain state machine

The startup probe now progresses through a bounded collect/drain flow. The important boundary is the read-chunk boundary: `setup_terminal()` does not stop in the middle of parsing a chunk just because DA was seen, or because the parser temporarily returned to ground. Exit checks are made only after the previous stdin chunk has been fully parsed by the probe parser.

```text
state = collecting
hard_deadline = now + hard_timeout

while true:
    # These checks observe the parser state after the previous read chunk was
    # fully parsed. A transient ground state inside a chunk is not a handoff point.
    if probe_parser.is_ground() and useful_probe_results_are_complete:
        state = finished
        break

    if probe_parser.is_ground() and DA_seen and now >= quiet_deadline:
        state = finished
        break

    if now >= hard_deadline:
        state = finished
        break

    read one stdin chunk using a timeout derived from:
        - quiet_deadline, when the probe parser is at ground
        - hard_deadline, when the probe parser is inside an unfinished VT sequence

    parse the entire chunk through the probe parser
    update collected probe results from complete OSC / CPR / DA tokens

    if DA was just seen:
        state = draining
        quiet_deadline = now + quiet_timeout

    if DA_seen and probe/control activity was observed:
        quiet_deadline = now + quiet_timeout

    if DA_seen and the chunk left the probe parser non-ground:
        keep reading through the same probe parser until it reaches ground,
        or until hard_deadline forces startup to continue
```

This means the normal handoff to the main loop requires both a probe completion condition and a clean parser boundary. If all useful probe results have already been collected but the probe parser is still inside `OSC`, `OscEsc`, `CSI`, or another unfinished VT sequence, the fast path is not taken. Startup continues reading with the probe parser until the sequence closes and the parser returns to ground, or until the hard deadline is reached.

Finishing startup probing means applying whatever complete probe results were collected, discarding the probe parser and any unfinished probe state, and only then creating the main-loop `vt::Parser` / `input::Parser`. Timeout reads are still passed through `vt::Parser::parse("")` so parser states that intentionally complete on timeout, such as a lone `ESC`, can settle before `setup_terminal()` decides whether the parser is back at ground.

## Validation

```text
cargo fmt --check
```

Passed with exit code 0. Stable rustfmt printed warnings for nightly-only rustfmt options in the repository config.

```text
cargo test -p edit
```

Passed:

- library tests: 46 passed, 1 ignored
- bin tests: 6 passed
- doctests: 2 passed

```text
CARGO_PROFILE_RELEASE_STRIP=false CARGO_PROFILE_RELEASE_DEBUG=full cargo build --release -p edit
```

Passed.

## Diagnostic context

The issue was reproduced over Windows Terminal + PowerShell + OpenSSH SSH into Linux on both `v2.0.0` and current `main` (`737450cef9ee40030221d1ddc4e91a5e67173306`). A local Codex-authored log-only diagnostic patch on current `main` captured startup response fragments where a DA response (`CSI ? 61;... c`) was followed by another OSC color response ending at a partial `ESC`. That temporary instrumentation logged the read stage, byte length, and an escaped representation of each stdin chunk before passing the same bytes to the existing parser; it did not reset parser state, reorder bytes, or include this PR's parser-lifecycle fix. The `main` release-with-symbols core showed:

- `tui.size == Size { width: 0, height: 0 }`
- framebuffer buffers were also `0x0`
- the shared `vt_parser` was still in `State::Osc`
- the last parsed CSI was the DA response

The stripped `v2.0.0` release binary manifested the same panic as SIGILL at `ud2`; release-with-symbols builds (`CARGO_PROFILE_RELEASE_STRIP=false CARGO_PROFILE_RELEASE_DEBUG=full cargo build --release -p edit`) showed the panic path through `Framebuffer::render()` / `Tui::render()`.

Separate log-only builds traced `setup_terminal()` input without adding this parser-lifecycle fix, preserving the original crash behavior. The linked issue includes the current `main` payload. The same lifecycle isolation applies to both the reproducing `v2.0.0` code path and current `main`.

## Design note

This PR keeps the scope targeted: it fixes the startup parser lifecycle leak and adds bounded probe draining, without redesigning all of terminal setup.

The repair is intentionally not terminal-specific compatibility code. It addresses an edit-side state-machine assumption: startup probing cannot rely on DA ordering to imply that all OSC replies have already arrived. The test payload uses ordinary ST-terminated OSC replies and ordered byte delivery; the hazardous part is handing a non-ground probe parser to the main input loop.

Parser isolation alone prevents the startup probe parser from consuming the first synthetic resize in the main loop, which fixes the panic. However, if setup stopped immediately after DA while the probe parser had already consumed the start of a later OSC reply, the remaining reply tail could be read by the fresh main parser without its `ESC ]` context and appear as editor text such as `0c0c/0c0c/0c0c`. The bounded drain keeps those follow-up bytes in the probe parser for the common delayed-response case.

It still treats DA (`CSI ... c`) as the signal that startup probing can begin winding down, not as proof that every earlier terminal query has completed. After DA, the probe parser keeps reading for a short quiet window, but only exits that path when the probe parser has returned to ground. That quiet window reads from the same stdin stream as real input, so extremely early typeahead can still be consumed during startup probing. I think that is an acceptable tradeoff for this startup phase: the main input parser has not been created yet, the main editor loop has not rendered the editable UI yet, and ignoring input before the editor is visibly editable matches the user-visible startup boundary. The window is intentionally short, and only probe/control activity can extend it. If the terminal leaves a control sequence unfinished, probing stops at a hard deadline rather than blocking startup indefinitely. In that extreme case a very late response tail may still reach the main loop, but the hard deadline is intentional: startup should not wait forever for a terminal response that may never complete.

A more complete terminal setup redesign would be a larger follow-up. It may be worth separating window-size initialization from terminal byte parsing more strongly: the current Unix path gets the real window size from the system, then encodes it as a synthetic `CSI 8 ; rows ; cols t` sequence so the input parser can produce `Input::Resize`. Replacing that with a typed resize event or direct TUI initialization would touch the sys/input/run-loop boundary, so I kept it out of this crash fix.




