### PR TITLE
Use copied() instead of cloned() for u16 iterator

### DIFF
--- a/crates/stdext/src/collections/string.rs
+++ b/crates/stdext/src/collections/string.rs
@@ -190,7 +190,7 @@ impl<'a> BString<'a> {
     pub fn push_utf16_lossy(&mut self, alloc: &'a dyn Allocator, string: &[u16]) {
         self.extend(
             alloc,
-            char::decode_utf16(string.iter().cloned())
+            char::decode_utf16(string.iter().copied())
                 .map(|r| r.unwrap_or(char::REPLACEMENT_CHARACTER)),
         );
     }


### PR DESCRIPTION
`push_utf16_lossy` iterates over a `&[u16]` and calls `.cloned()`. Since `u16` is `Copy`, `.copied()` is the idiomatic choice here — it states intent more precisely and is what Clippy's `cloned_instead_of_copied` lint recommends. No behaviour change.