### PR TITLE
Add syntax highlighting grammars for more languages

### DIFF
--- a/assets/highlighting-tests/c.c
+++ b/assets/highlighting-tests/c.c
@@ -1,0 +1,56 @@
+// Line comment
+/* Block comment
+   spanning lines */
+
+#include <stdio.h>
+#include <stdint.h>
+#define MAX 100
+#ifndef GUARD_H
+#define GUARD_H
+
+typedef struct Point {
+    double x;
+    double y;
+} Point;
+
+enum Color { RED, GREEN, BLUE };
+
+static const char *NAME = "edit";
+
+void numbers(void) {
+    int a = 42;
+    unsigned long b = 0xffUL;
+    int c = 0b1010;
+    double d = 1.5e-3;
+    float f = 3.14f;
+    long long g = 1000000LL;
+}
+
+void strings(void) {
+    const char *s = "double \" quote \n escape";
+    char ch = 'a';
+    char nl = '\n';
+    wchar_t w = L'x';
+}
+
+int control(int n) {
+    for (int i = 0; i < n; i++) {
+        if (i == 5) continue;
+        switch (i) {
+            case 1: break;
+            default: break;
+        }
+    }
+    while (n > 0) { n--; }
+    return n;
+}
+
+int main(int argc, char **argv) {
+    Point p = { .x = 1.0, .y = 2.0 };
+    _Bool flag = true;
+    printf("%f %d\n", p.x, flag);
+    if (argv == NULL) return 1;
+    return 0;
+}
+
+#endif

--- a/assets/highlighting-tests/cpp.cpp
+++ b/assets/highlighting-tests/cpp.cpp
@@ -1,0 +1,61 @@
+// Line comment
+/* Block comment
+   spanning lines */
+
+#include <string>
+#include <vector>
+#include <memory>
+#pragma once
+
+namespace geometry {
+
+template <typename T>
+class Point {
+public:
+    Point(T x, T y) : x_(x), y_(y) {}
+    T x() const { return x_; }
+
+private:
+    T x_;
+    T y_;
+};
+
+enum class Color { Red, Green, Blue };
+
+constexpr double kPi = 3.14159;
+
+void numbers() {
+    int a = 42;
+    auto b = 0xffUL;
+    auto c = 0b1010;
+    double d = 1.5e-3;
+    float f = 3.14f;
+    auto z = 100uz;
+}
+
+void strings() {
+    std::string s = "double \" quote \n escape";
+    auto raw = R"(raw "string" \n no escape)";
+    char ch = 'a';
+    char nl = '\n';
+}
+
+int control(int n) {
+    for (int i = 0; i < n; ++i) {
+        if (i == 5) continue;
+        try {
+            throw std::runtime_error("oops");
+        } catch (const std::exception& e) {
+        }
+    }
+    return n;
+}
+
+} // namespace geometry
+
+int main() {
+    auto p = std::make_unique<geometry::Point<double>>(1.0, 2.0);
+    bool flag = true;
+    std::vector<int> v{1, 2, 3};
+    return flag ? 0 : nullptr != p.get();
+}

--- a/assets/highlighting-tests/css.css
+++ b/assets/highlighting-tests/css.css
@@ -1,0 +1,48 @@
+/* Block comment
+   spanning lines */
+
+@import "reset.css";
+
+:root {
+  --primary: #3366ff;
+  --spacing: 8px;
+}
+
+body {
+  margin: 0;
+  padding: 1.5rem;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #333;
+  background: #ffffff;
+}
+
+.container {
+  display: flex;
+  width: 100%;
+  max-width: 960px;
+  transform: rotate(45deg);
+  transition: all 0.3s ease-in-out;
+}
+
+#header,
+.nav > li {
+  color: rgba(0, 0, 0, 0.8);
+  content: "hello \" world";
+  z-index: 10 !important;
+}
+
+@media (max-width: 600px) {
+  .container {
+    flex-direction: column;
+  }
+}
+
+@keyframes fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/assets/highlighting-tests/go.go
+++ b/assets/highlighting-tests/go.go
@@ -1,0 +1,60 @@
+// Line comment
+/* Block comment
+   spanning lines */
+
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+const Pi = 3.14159
+
+type Point struct {
+	X, Y float64
+}
+
+func numbers() {
+	_ = 42
+	_ = 0xff
+	_ = 0b1010
+	_ = 0o77
+	_ = 1_000_000
+	_ = 1.5e-3
+	_ = 3.14i
+}
+
+func stringLiterals() {
+	_ = "double \" quote \n escape"
+	_ = `raw string
+	spanning lines \n no escape`
+	_ = 'a'
+	_ = '\n'
+}
+
+func control(n int) int {
+	for i := 0; i < n; i++ {
+		if i == 5 {
+			continue
+		}
+		switch i {
+		case 1:
+			break
+		default:
+			fallthrough
+		}
+	}
+	return n
+}
+
+func (p Point) String() string {
+	return fmt.Sprintf("(%v, %v)", p.X, p.Y)
+}
+
+func main() {
+	p := Point{X: 1.0, Y: 2.0}
+	var b bool = true
+	var s string = strings.ToUpper("hi")
+	fmt.Println(p.String(), b, s, nil)
+}

--- a/assets/highlighting-tests/rust.rs
+++ b/assets/highlighting-tests/rust.rs
@@ -1,0 +1,72 @@
+// Line comment
+/* Block comment
+   spanning lines */
+
+//! Inner doc comment
+/// Outer doc comment
+
+#![allow(dead_code)]
+#[derive(Debug, Clone)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+const MAX: usize = 100;
+static NAME: &str = "edit";
+
+fn numbers() {
+    let _ = 42;
+    let _ = 3.14;
+    let _ = 0xff_u8;
+    let _ = 0b1010;
+    let _ = 0o77;
+    let _ = 1_000_000i64;
+    let _ = 1.5e-3;
+}
+
+fn strings() {
+    let _ = "double \" quote \n escape";
+    let _ = r"raw string \n no escape";
+    let _ = r#"raw with "quotes" inside"#;
+    let _ = b"byte string";
+    let _ = 'a';
+    let _ = '\n';
+}
+
+fn lifetimes<'a>(s: &'a str) -> &'a str {
+    s
+}
+
+fn control(n: i32) -> Option<i32> {
+    for i in 0..n {
+        if i == 5 {
+            continue;
+        }
+        while i < 10 {
+            break;
+        }
+    }
+    match n {
+        0 => None,
+        _ => Some(n),
+    }
+}
+
+pub trait Greet {
+    fn greet(&self) -> String;
+}
+
+impl Greet for Point {
+    fn greet(&self) -> String {
+        format!("({}, {})", self.x, self.y)
+    }
+}
+
+fn main() {
+    let p = Point { x: 1.0, y: 2.0 };
+    println!("{}", p.greet());
+    let v: Vec<i32> = vec![1, 2, 3];
+    let b = true;
+    let _ = if b { Ok(()) } else { Err(()) };
+}

--- a/assets/highlighting-tests/toml.toml
+++ b/assets/highlighting-tests/toml.toml
@@ -1,0 +1,44 @@
+# Line comment
+
+title = "TOML example"
+enabled = true
+disabled = false
+
+# Numbers
+int1 = 42
+int2 = 0xff
+int3 = 0b1010
+int4 = 0o77
+int5 = 1_000_000
+float1 = 3.14
+float2 = 1.5e-3
+float3 = inf
+float4 = nan
+
+# Dates
+date1 = 2026-07-06
+datetime1 = 2026-07-06T12:30:00Z
+datetime2 = 2026-07-06 12:30:00.5+02:00
+
+# Strings
+basic = "double \" quote \n escape"
+literal = 'no \n escape here'
+multiline = """
+multi-line
+basic string
+"""
+multiline_literal = '''
+multi-line
+literal string
+'''
+
+[package]
+name = "edit"
+version = "1.0.0"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+
+[[bin]]
+name = "edit"
+path = "src/main.rs"

--- a/assets/highlighting-tests/typescript.ts
+++ b/assets/highlighting-tests/typescript.ts
@@ -1,0 +1,66 @@
+// Line comment
+/* Block comment
+   spanning lines */
+
+// Numbers
+const n1 = 42;
+const n2 = 3.14;
+const n3 = 0xff;
+const n4 = 0b1010;
+const n5 = 1_000_000;
+const n6 = 42n;
+
+// Constants
+const c1 = true;
+const c2 = null;
+const c3 = undefined;
+
+// Strings
+const s1 = 'single \' quote';
+const s2 = "double \" quote";
+const s3 = `template ${1 + 2} literal`;
+
+// Types and interfaces
+type ID = string | number;
+
+interface Point {
+  readonly x: number;
+  y: number;
+}
+
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+
+@sealed
+class Shape implements Point {
+  x: number = 0;
+  y: number = 0;
+  private label: string;
+
+  constructor(label: string) {
+    this.label = label;
+  }
+
+  area(): number {
+    return this.x * this.y;
+  }
+}
+
+function identity<T>(value: T): T {
+  return value;
+}
+
+const nums: Array<number> = [1, 2, 3];
+const result = nums.map((x): number => x * 2);
+
+async function load(): Promise<Point> {
+  const p = await Promise.resolve({ x: 1, y: 2 });
+  return p as Point;
+}
+
+for (const x of nums) {
+  if (x === 2) continue;
+}

--- a/crates/edit/src/bin/edit/documents.rs
+++ b/crates/edit/src/bin/edit/documents.rs
@@ -43,6 +43,11 @@ impl Document {
             self.set_path(path);
         }
 
+        // If this was the settings file, request a live reload of settings.
+        if let Some(path) = self.path.as_deref() {
+            Settings::note_saved(path);
+        }
+
         Ok(())
     }
 

--- a/crates/edit/src/bin/edit/draw_editor.rs
+++ b/crates/edit/src/bin/edit/draw_editor.rs
@@ -86,6 +86,7 @@ fn draw_file_pane(ctx: &mut Context, state: &mut State, content_height: CoordTyp
 
     let mut navigate_to: Option<PathBuf> = None;
     let mut open_file: Option<PathBuf> = None;
+    let mut close_pane = false;
 
     ctx.block_begin("file-pane");
     ctx.attr_focus_well();
@@ -95,6 +96,13 @@ fn draw_file_pane(ctx: &mut Context, state: &mut State, content_height: CoordTyp
     {
         let contains_focus = ctx.contains_focus();
 
+        // Header: a right-aligned [X] button to close the pane, then the
+        // current directory.
+        if ctx.button("close", "X", ButtonStyle::default()) {
+            close_pane = true;
+        }
+        ctx.attr_position(Position::Right);
+
         ctx.label("dir", state.file_pane_dir.as_str());
         ctx.attr_overflow(Overflow::TruncateMiddle);
 
@@ -102,7 +110,7 @@ fn draw_file_pane(ctx: &mut Context, state: &mut State, content_height: CoordTyp
             state.wants_editor_focus = true;
         }
 
-        ctx.scrollarea_begin("file-pane-scroll", Size { width: 0, height: content_height - 3 });
+        ctx.scrollarea_begin("file-pane-scroll", Size { width: 0, height: content_height - 4 });
         {
             ctx.next_block_id_mixin(state.file_pane_dir_revision);
             ctx.list_begin("entries");
@@ -137,6 +145,13 @@ fn draw_file_pane(ctx: &mut Context, state: &mut State, content_height: CoordTyp
     ctx.block_end();
 
     state.file_pane_focus = false;
+
+    if close_pane {
+        state.file_pane_visible = false;
+        state.wants_editor_focus = true;
+        ctx.needs_rerender();
+        return;
+    }
 
     if let Some(dir) = navigate_to {
         state.file_pane_dir = DisplayablePathBuf::from_path(dir);

--- a/crates/edit/src/bin/edit/draw_editor.rs
+++ b/crates/edit/src/bin/edit/draw_editor.rs
@@ -399,9 +399,13 @@ pub fn draw_handle_wants_close(ctx: &mut Context, state: &mut State) {
     }
     let mut action = Action::None;
 
+    // Derive the foreground from the background so it stays legible regardless
+    // of the theme. A hardcoded BrightWhite is too light on themes whose Red is
+    // a light color (e.g. Catppuccin).
+    let bg = ctx.indexed(IndexedColor::Red);
     ctx.modal_begin("unsaved-changes", loc(LocId::UnsavedChangesDialogTitle));
-    ctx.attr_background_rgba(ctx.indexed(IndexedColor::Red));
-    ctx.attr_foreground_rgba(ctx.indexed(IndexedColor::BrightWhite));
+    ctx.attr_background_rgba(bg);
+    ctx.attr_foreground_rgba(ctx.contrasted(bg));
     {
         let contains_focus = ctx.contains_focus();
 

--- a/crates/edit/src/bin/edit/draw_editor.rs
+++ b/crates/edit/src/bin/edit/draw_editor.rs
@@ -252,8 +252,12 @@ fn draw_search(ctx: &mut Context, state: &mut State) {
                     action = Some(SearchAction::Search);
                 }
                 if !state.search_success {
-                    ctx.attr_background_rgba(ctx.indexed(IndexedColor::Red));
-                    ctx.attr_foreground_rgba(ctx.indexed(IndexedColor::BrightWhite));
+                    // Derive the foreground from the background so it stays
+                    // legible on themes whose Red is a light color (e.g.
+                    // Catppuccin), instead of a hardcoded BrightWhite.
+                    let bg = ctx.indexed(IndexedColor::Red);
+                    ctx.attr_background_rgba(bg);
+                    ctx.attr_foreground_rgba(ctx.contrasted(bg));
                 }
                 ctx.attr_intrinsic_size(Size { width: COORD_TYPE_SAFE_MAX, height: 1 });
                 if focus == StateSearchKind::Search {

--- a/crates/edit/src/bin/edit/draw_editor.rs
+++ b/crates/edit/src/bin/edit/draw_editor.rs
@@ -1,17 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use std::fs;
 use std::num::ParseIntError;
+use std::path::PathBuf;
 
 use edit::framebuffer::IndexedColor;
 use edit::helpers::*;
-use edit::icu;
 use edit::input::{kbmod, vk};
 use edit::tui::*;
+use edit::{icu, path};
 use stdext::string_from_utf8_lossy_owned;
 
 use crate::localization::*;
 use crate::state::*;
+
+/// Width in columns of the file browser pane, including its border.
+const FILE_PANE_WIDTH: CoordType = 30;
 
 pub fn draw_editor(ctx: &mut Context, state: &mut State) {
     if !matches!(state.wants_search.kind, StateSearchKind::Hidden | StateSearchKind::Disabled) {
@@ -25,16 +30,164 @@ pub fn draw_editor(ctx: &mut Context, state: &mut State) {
         StateSearchKind::Replace => 5,
         _ => 2,
     };
+    let content_height = size.height - height_reduction;
 
+    if state.file_pane_visible {
+        ctx.table_begin("editor-row");
+        ctx.table_set_columns(&[FILE_PANE_WIDTH, COORD_TYPE_SAFE_MAX]);
+        ctx.attr_intrinsic_size(Size { width: 0, height: content_height });
+        {
+            ctx.table_next_row();
+
+            draw_file_pane(ctx, state, content_height);
+            draw_editor_area(ctx, state, content_height);
+        }
+        ctx.table_end();
+    } else {
+        draw_editor_area(ctx, state, content_height);
+    }
+}
+
+fn draw_editor_area(ctx: &mut Context, state: &mut State, content_height: CoordType) {
     if let Some(doc) = state.documents.active() {
         ctx.textarea("textarea", doc.buffer.clone());
         ctx.inherit_focus();
+        if state.wants_editor_focus {
+            state.wants_editor_focus = false;
+            ctx.steal_focus();
+        }
     } else {
+        state.wants_editor_focus = false;
         ctx.block_begin("empty");
         ctx.block_end();
     }
 
-    ctx.attr_intrinsic_size(Size { width: 0, height: size.height - height_reduction });
+    ctx.attr_intrinsic_size(Size { width: 0, height: content_height });
+}
+
+/// Draws the Yazi-like file browser pane on the left-hand side.
+fn draw_file_pane(ctx: &mut Context, state: &mut State, content_height: CoordType) {
+    // Initialize the directory to the active document's directory (or the CWD)
+    // the first time the pane is shown.
+    if state.file_pane_dir.as_path().as_os_str().is_empty() {
+        let dir = state
+            .documents
+            .active()
+            .and_then(|doc| doc.dir.as_ref().map(|d| d.as_path().to_path_buf()))
+            .or_else(|| std::env::current_dir().ok())
+            .unwrap_or_default();
+        state.file_pane_dir = DisplayablePathBuf::from_path(dir);
+        state.file_pane_entries = None;
+    }
+
+    if state.file_pane_entries.is_none() {
+        refresh_file_pane_entries(state);
+    }
+
+    let mut navigate_to: Option<PathBuf> = None;
+    let mut open_file: Option<PathBuf> = None;
+
+    ctx.block_begin("file-pane");
+    ctx.attr_focus_well();
+    ctx.attr_border();
+    ctx.attr_background_rgba(ctx.indexed_alpha(IndexedColor::Black, 1, 4));
+    ctx.attr_intrinsic_size(Size { width: FILE_PANE_WIDTH, height: content_height });
+    {
+        let contains_focus = ctx.contains_focus();
+
+        ctx.label("dir", state.file_pane_dir.as_str());
+        ctx.attr_overflow(Overflow::TruncateMiddle);
+
+        if contains_focus && ctx.consume_shortcut(vk::ESCAPE) {
+            state.wants_editor_focus = true;
+        }
+
+        ctx.scrollarea_begin("file-pane-scroll", Size { width: 0, height: content_height - 3 });
+        {
+            ctx.next_block_id_mixin(state.file_pane_dir_revision);
+            ctx.list_begin("entries");
+
+            let mut first = true;
+            for entries in state.file_pane_entries.as_ref().unwrap() {
+                for entry in entries {
+                    let sel = ctx.list_item(false, entry.as_str());
+                    ctx.attr_overflow(Overflow::TruncateMiddle);
+
+                    if first && state.file_pane_focus {
+                        ctx.list_item_steal_focus();
+                    }
+                    first = false;
+
+                    if sel == ListSelection::Activated {
+                        let path =
+                            path::normalize(&state.file_pane_dir.as_path().join(entry.as_path()));
+                        if path.is_dir() {
+                            navigate_to = Some(path);
+                        } else {
+                            open_file = Some(path);
+                        }
+                    }
+                }
+            }
+
+            ctx.list_end();
+        }
+        ctx.scrollarea_end();
+    }
+    ctx.block_end();
+
+    state.file_pane_focus = false;
+
+    if let Some(dir) = navigate_to {
+        state.file_pane_dir = DisplayablePathBuf::from_path(dir);
+        state.file_pane_dir_revision = state.file_pane_dir_revision.wrapping_add(1);
+        state.file_pane_entries = None;
+        ctx.needs_rerender();
+    } else if let Some(path) = open_file {
+        match state.documents.add_file_path(&path) {
+            Ok(..) => {
+                state.wants_editor_focus = true;
+                ctx.needs_rerender();
+            }
+            Err(err) => error_log_add(ctx, state, err),
+        }
+    }
+}
+
+/// Reads the contents of `state.file_pane_dir` into `state.file_pane_entries`.
+/// Handles inaccessible directories gracefully (yields an empty listing).
+fn refresh_file_pane_entries(state: &mut State) {
+    let dir = state.file_pane_dir.as_path();
+    // ["..", directories, files]
+    let mut dirs_files = [Vec::new(), Vec::new(), Vec::new()];
+
+    if cfg!(windows) || dir.parent().is_some() {
+        dirs_files[0].push(DisplayablePathBuf::from(".."));
+    }
+
+    if let Ok(iter) = fs::read_dir(dir) {
+        for entry in iter.flatten() {
+            if let Ok(metadata) = entry.metadata() {
+                let mut name = entry.file_name();
+                let is_dir = metadata.is_dir()
+                    || (metadata.is_symlink()
+                        && fs::metadata(entry.path()).is_ok_and(|m| m.is_dir()));
+                let idx = if is_dir { 1 } else { 2 };
+
+                if is_dir {
+                    name.push("/");
+                }
+
+                dirs_files[idx].push(DisplayablePathBuf::from(name));
+            }
+        }
+    }
+
+    for entries in &mut dirs_files[1..] {
+        entries.sort_unstable_by(|a, b| icu::compare_strings(a.as_bytes(), b.as_bytes()));
+    }
+
+    state.file_pane_entries = Some(dirs_files);
 }
 
 fn draw_search(ctx: &mut Context, state: &mut State) {

--- a/crates/edit/src/bin/edit/draw_menubar.rs
+++ b/crates/edit/src/bin/edit/draw_menubar.rs
@@ -142,6 +142,18 @@ fn draw_menu_view(ctx: &mut Context, state: &mut State) {
         }
     }
 
+    // The menu item toggles visibility. Focusing the pane is bound to the
+    // Ctrl+B shortcut instead (handled globally), so no shortcut is shown here.
+    if ctx.menubar_menu_checkbox(loc(LocId::ViewFilePane), 'B', vk::NULL, state.file_pane_visible) {
+        state.file_pane_visible = !state.file_pane_visible;
+        if state.file_pane_visible {
+            state.file_pane_focus = true;
+        } else {
+            state.wants_editor_focus = true;
+        }
+        ctx.needs_rerender();
+    }
+
     ctx.menubar_menu_end();
 }
 

--- a/crates/edit/src/bin/edit/main.rs
+++ b/crates/edit/src/bin/edit/main.rs
@@ -93,27 +93,14 @@ fn run() -> apperr::Result<()> {
     let mut input_parser = input::Parser::new();
     let mut tui = Tui::new()?;
 
-    let _restore = setup_terminal(&mut tui, &mut state, &mut vt_parser);
+    let _restore = setup_terminal(&mut state, &mut vt_parser);
 
-    state.menubar_color_bg = tui.indexed(IndexedColor::Background).oklab_blend(tui.indexed_alpha(
-        IndexedColor::BrightBlue,
-        1,
-        2,
-    ));
-    state.menubar_color_fg = tui.contrasted(state.menubar_color_bg);
-    let floater_bg = tui
-        .indexed_alpha(IndexedColor::Background, 2, 3)
-        .oklab_blend(tui.indexed_alpha(IndexedColor::Foreground, 1, 3));
-    let floater_fg = tui.contrasted(floater_bg);
     tui.setup_modifier_translations(ModifierTranslations {
         ctrl: loc(LocId::Ctrl),
         alt: loc(LocId::Alt),
         shift: loc(LocId::Shift),
     });
-    tui.set_floater_default_bg(floater_bg);
-    tui.set_floater_default_fg(floater_fg);
-    tui.set_modal_default_bg(floater_bg);
-    tui.set_modal_default_fg(floater_fg);
+    apply_theme_colors(&mut tui, &mut state);
 
     sys::inject_window_size_into_stdin();
 
@@ -174,6 +161,25 @@ fn run() -> apperr::Result<()> {
 
         if state.exit {
             break;
+        }
+
+        // A saved settings.json requests a live reload, so theme changes (and
+        // other settings) apply without a restart. Re-apply the palette and
+        // redraw before rendering, so the new colors are captured this frame.
+        if Settings::take_reload_request() {
+            if let Err(err) = Settings::reload() {
+                state.add_error(err);
+            }
+            apply_theme_colors(&mut tui, &mut state);
+
+            {
+                let mut ctx = tui.create_context(None);
+                draw(&mut ctx, &mut state);
+            }
+            while tui.needs_settling() {
+                let mut ctx = tui.create_context(None);
+                draw(&mut ctx, &mut state);
+            }
         }
 
         // Render the UI and write it to the terminal.
@@ -567,7 +573,7 @@ impl Drop for RestoreModes {
     }
 }
 
-fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) -> RestoreModes {
+fn setup_terminal(state: &mut State, vt_parser: &mut vt::Parser) -> RestoreModes {
     sys::write_stdout(concat!(
         // 1049: Alternative Screen Buffer
         //   I put the ASB switch in the beginning, just in case the terminal performs
@@ -680,8 +686,23 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
         state.documents.reflow_all();
     }
 
-    // A configured theme overrides the terminal's own palette. Unlike the
-    // OSC-queried colors, it doesn't depend on the terminal answering our
+    // Remember the terminal's own palette (when the terminal answered all our
+    // OSC queries) so it can be restored if the `theme` setting is later
+    // switched back to `system`. The palette itself is applied by
+    // `apply_theme_colors`, which also honors a configured fixed theme.
+    if color_responses == indexed_colors.len() {
+        state.system_theme = indexed_colors;
+    }
+
+    RestoreModes
+}
+
+/// Applies the palette for the currently configured [`Theme`] and recomputes
+/// the derived UI colors (menubar, floaters, modals). Safe to call again after
+/// the `theme` setting changes, so themes can be switched live.
+fn apply_theme_colors(tui: &mut Tui, state: &mut State) {
+    // A fixed theme overrides the terminal's own palette. Unlike the
+    // OSC-queried colors it doesn't depend on the terminal answering our
     // queries, so it applies unconditionally. We also actively paint its base
     // background/foreground, so the editing surface uses the theme's base color
     // rather than the terminal's (which won't match a fixed palette).
@@ -691,11 +712,24 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
             palette[IndexedColor::Background as usize],
             palette[IndexedColor::Foreground as usize],
         );
-    } else if color_responses == indexed_colors.len() {
-        tui.setup_indexed_colors(indexed_colors);
+    } else {
+        tui.setup_indexed_colors(state.system_theme);
     }
 
-    RestoreModes
+    state.menubar_color_bg = tui.indexed(IndexedColor::Background).oklab_blend(tui.indexed_alpha(
+        IndexedColor::BrightBlue,
+        1,
+        2,
+    ));
+    state.menubar_color_fg = tui.contrasted(state.menubar_color_bg);
+    let floater_bg = tui
+        .indexed_alpha(IndexedColor::Background, 2, 3)
+        .oklab_blend(tui.indexed_alpha(IndexedColor::Foreground, 1, 3));
+    let floater_fg = tui.contrasted(floater_bg);
+    tui.set_floater_default_bg(floater_bg);
+    tui.set_floater_default_fg(floater_fg);
+    tui.set_modal_default_bg(floater_bg);
+    tui.set_modal_default_fg(floater_fg);
 }
 
 /// Strips all C0 control characters from the string and replaces them with "_".

--- a/crates/edit/src/bin/edit/main.rs
+++ b/crates/edit/src/bin/edit/main.rs
@@ -385,6 +385,11 @@ fn draw(ctx: &mut Context, state: &mut State) {
             state.wants_exit = true;
         } else if key == kbmod::CTRL | vk::G {
             state.wants_goto = true;
+        } else if key == kbmod::CTRL | vk::B {
+            // Focus the file browser pane, showing it first if it's hidden.
+            // (Toggling visibility is done from the View menu.)
+            state.file_pane_visible = true;
+            state.file_pane_focus = true;
         } else if key == kbmod::CTRL | vk::F && state.wants_search.kind != StateSearchKind::Disabled
         {
             state.wants_search.kind = StateSearchKind::Search;

--- a/crates/edit/src/bin/edit/main.rs
+++ b/crates/edit/src/bin/edit/main.rs
@@ -47,7 +47,7 @@ fn main() -> process::ExitCode {
     if cfg!(debug_assertions) {
         let hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {
-            drop(RestoreModes);
+            drop(RestoreModes { kitty_enabled: false });
             drop(sys::Deinit);
             hook(info);
         }));
@@ -556,10 +556,17 @@ fn write_osc_clipboard<'a>(
     state.osc_clipboard_sync = false;
 }
 
-struct RestoreModes;
+struct RestoreModes {
+    /// Whether we pushed Kitty keyboard protocol flags and thus need to pop them.
+    kitty_enabled: bool,
+}
 
 impl Drop for RestoreModes {
     fn drop(&mut self) {
+        // Pop the Kitty keyboard protocol flags we pushed during setup, if any.
+        if self.kitty_enabled {
+            sys::write_stdout("\x1b[<u");
+        }
         // Same as in the beginning but in the reverse order.
         // It also includes DECSCUSR 0 to reset the cursor style and DECTCEM to show the cursor.
         // We specifically don't reset mode 1036, because most applications expect it to be set nowadays.
@@ -588,6 +595,11 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
         // actual display width of the character and assigns it columns accordingly.
         // We detect it by writing the character and asking for the cursor position.
         "\r…\x1b[6n",
+        // Query the current Kitty keyboard protocol flags. Terminals that
+        // support the protocol reply with `CSI ? <flags> u`; others stay silent.
+        // We use this to gate enabling the protocol (see below), so that
+        // non-supporting terminals are entirely unaffected.
+        "\x1b[?u",
         // CSI c reports the terminal capabilities.
         // It also helps us to detect the end of the responses, because not all
         // terminals support the OSC queries, but all of them support CSI c.
@@ -599,6 +611,7 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
     let mut indexed_colors = framebuffer::DEFAULT_THEME;
     let mut color_responses = 0;
     let mut ambiguous_width = 1;
+    let mut kitty_supported = false;
 
     while !done {
         let scratch = scratch_arena(None);
@@ -615,6 +628,8 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
             match token {
                 Token::Csi(csi) => match csi.final_byte {
                     'c' => done = true,
+                    // Kitty keyboard protocol flags report: `CSI ? <flags> u`.
+                    'u' if csi.private_byte == '?' => kitty_supported = true,
                     // CPR (Cursor Position Report) response.
                     'R' => ambiguous_width = csi.params[1] as CoordType - 1,
                     _ => {}
@@ -684,7 +699,15 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
         tui.setup_indexed_colors(indexed_colors);
     }
 
-    RestoreModes
+    // Only enable the Kitty keyboard protocol if the terminal advertised support.
+    // Flag 1 ("disambiguate escape codes") is enough to receive the Super (Command)
+    // modifier on letters, enabling macOS-style Cmd+C/V/X, while plain text still
+    // arrives as normal text input.
+    if kitty_supported {
+        sys::write_stdout("\x1b[>1u");
+    }
+
+    RestoreModes { kitty_enabled: kitty_supported }
 }
 
 /// Strips all C0 control characters from the string and replaces them with "_".

--- a/crates/edit/src/bin/edit/main.rs
+++ b/crates/edit/src/bin/edit/main.rs
@@ -680,7 +680,18 @@ fn setup_terminal(tui: &mut Tui, state: &mut State, vt_parser: &mut vt::Parser) 
         state.documents.reflow_all();
     }
 
-    if color_responses == indexed_colors.len() {
+    // A configured theme overrides the terminal's own palette. Unlike the
+    // OSC-queried colors, it doesn't depend on the terminal answering our
+    // queries, so it applies unconditionally. We also actively paint its base
+    // background/foreground, so the editing surface uses the theme's base color
+    // rather than the terminal's (which won't match a fixed palette).
+    if let Some(palette) = Settings::borrow().theme.palette() {
+        tui.setup_indexed_colors(palette);
+        tui.set_base_fill(
+            palette[IndexedColor::Background as usize],
+            palette[IndexedColor::Foreground as usize],
+        );
+    } else if color_responses == indexed_colors.len() {
         tui.setup_indexed_colors(indexed_colors);
     }
 

--- a/crates/edit/src/bin/edit/settings.rs
+++ b/crates/edit/src/bin/edit/settings.rs
@@ -2,16 +2,59 @@ use std::path::PathBuf;
 
 use edit::buffer::TextBuffer;
 use edit::cell::{Ref, SemiRefCell};
+use edit::framebuffer::{
+    CATPPUCCIN_FRAPPE, CATPPUCCIN_LATTE, CATPPUCCIN_MACCHIATO, CATPPUCCIN_MOCHA,
+    INDEXED_COLORS_COUNT,
+};
 use edit::json;
 use edit::lsh::{LANGUAGES, Language};
+use edit::oklab::StraightRgba;
 use stdext::arena::{read_to_string, scratch_arena};
 use stdext::arena_format;
 
 use crate::apperr;
 
+/// The color theme to use for the editor.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub enum Theme {
+    /// Follow the terminal's own color palette (queried via OSC). The default.
+    #[default]
+    System,
+    CatppuccinLatte,
+    CatppuccinFrappe,
+    CatppuccinMacchiato,
+    CatppuccinMocha,
+}
+
+impl Theme {
+    fn from_id(id: &str) -> Option<Self> {
+        Some(match id {
+            "system" => Theme::System,
+            "catppuccin-latte" => Theme::CatppuccinLatte,
+            "catppuccin-frappe" => Theme::CatppuccinFrappe,
+            "catppuccin-macchiato" => Theme::CatppuccinMacchiato,
+            "catppuccin-mocha" => Theme::CatppuccinMocha,
+            _ => return None,
+        })
+    }
+
+    /// The fixed palette for this theme, or `None` when the terminal's
+    /// own palette should be used ([`Theme::System`]).
+    pub fn palette(self) -> Option<[StraightRgba; INDEXED_COLORS_COUNT]> {
+        Some(match self {
+            Theme::System => return None,
+            Theme::CatppuccinLatte => CATPPUCCIN_LATTE,
+            Theme::CatppuccinFrappe => CATPPUCCIN_FRAPPE,
+            Theme::CatppuccinMacchiato => CATPPUCCIN_MACCHIATO,
+            Theme::CatppuccinMocha => CATPPUCCIN_MOCHA,
+        })
+    }
+}
+
 pub struct Settings {
     pub path: PathBuf,
     pub file_associations: Vec<(String, &'static Language)>,
+    pub theme: Theme,
 }
 
 struct SettingsCell(SemiRefCell<Settings>);
@@ -22,21 +65,29 @@ impl Settings {
     /// Fills the given settings.json text buffer with some initial contents for convenience.
     pub fn bootstrap(tb: &mut TextBuffer) {
         tb.set_crlf(false);
-        tb.write_raw(concat!(
-            "{\n",
-            "    // Maps file name globs to language IDs for syntax highlighting.\n",
-            "    // The default is empty (associations are inferred automatically).\n",
-            "    // \"files.associations\": {\n",
-            "    //     \"*.txt\": \"plaintext\"\n",
-            "    // }\n",
-            "}\n",
-        ).as_bytes());
+        tb.write_raw(
+            concat!(
+                "{\n",
+                "    // Color theme. One of: \"system\" (follow the terminal palette),\n",
+                "    // \"catppuccin-latte\", \"catppuccin-frappe\", \"catppuccin-macchiato\",\n",
+                "    // \"catppuccin-mocha\".\n",
+                "    // \"theme\": \"system\",\n",
+                "\n",
+                "    // Maps file name globs to language IDs for syntax highlighting.\n",
+                "    // The default is empty (associations are inferred automatically).\n",
+                "    // \"files.associations\": {\n",
+                "    //     \"*.txt\": \"plaintext\"\n",
+                "    // }\n",
+                "}\n",
+            )
+            .as_bytes(),
+        );
         tb.cursor_move_to_logical(Default::default());
         tb.mark_as_clean();
     }
 
     const fn new() -> Self {
-        Settings { path: PathBuf::new(), file_associations: Vec::new() }
+        Settings { path: PathBuf::new(), file_associations: Vec::new(), theme: Theme::System }
     }
 
     pub fn borrow() -> Ref<'static, Settings> {
@@ -72,6 +123,16 @@ impl Settings {
         let Some(root) = json.as_object() else {
             return Err(apperr::Error::SettingsInvalid("Non-object root"));
         };
+
+        if let Some(value) = root.get("theme") {
+            let Some(id) = value.as_str() else {
+                return Err(apperr::Error::SettingsInvalid("theme"));
+            };
+            let Some(theme) = Theme::from_id(id) else {
+                return Err(apperr::Error::SettingsInvalid("theme"));
+            };
+            self.theme = theme;
+        }
 
         if let Some(f) = root.get_object("files.associations") {
             for &(mut key, ref value) in f.iter() {

--- a/crates/edit/src/bin/edit/settings.rs
+++ b/crates/edit/src/bin/edit/settings.rs
@@ -22,7 +22,15 @@ impl Settings {
     /// Fills the given settings.json text buffer with some initial contents for convenience.
     pub fn bootstrap(tb: &mut TextBuffer) {
         tb.set_crlf(false);
-        tb.write_raw(b"{\n}\n");
+        tb.write_raw(concat!(
+            "{\n",
+            "    // Maps file name globs to language IDs for syntax highlighting.\n",
+            "    // The default is empty (associations are inferred automatically).\n",
+            "    // \"files.associations\": {\n",
+            "    //     \"*.txt\": \"plaintext\"\n",
+            "    // }\n",
+            "}\n",
+        ).as_bytes());
         tb.cursor_move_to_logical(Default::default());
         tb.mark_as_clean();
     }

--- a/crates/edit/src/bin/edit/settings.rs
+++ b/crates/edit/src/bin/edit/settings.rs
@@ -1,4 +1,6 @@
+use std::path::Path;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use edit::buffer::TextBuffer;
 use edit::cell::{Ref, SemiRefCell};
@@ -61,6 +63,10 @@ struct SettingsCell(SemiRefCell<Settings>);
 unsafe impl Sync for SettingsCell {}
 static SETTINGS: SettingsCell = SettingsCell(SemiRefCell::new(Settings::new()));
 
+/// Set when the settings file is saved from within the editor, so the main
+/// loop knows to reload settings and re-apply the theme without a restart.
+static RELOAD_REQUESTED: AtomicBool = AtomicBool::new(false);
+
 impl Settings {
     /// Fills the given settings.json text buffer with some initial contents for convenience.
     pub fn bootstrap(tb: &mut TextBuffer) {
@@ -92,6 +98,23 @@ impl Settings {
 
     pub fn borrow() -> Ref<'static, Settings> {
         SETTINGS.0.borrow()
+    }
+
+    /// If the given path is the settings file, flags a reload for the main loop.
+    /// Called after a document is saved, so editing settings.json applies live.
+    pub fn note_saved(path: &Path) {
+        let is_settings = {
+            let s = SETTINGS.0.borrow();
+            !s.path.as_os_str().is_empty() && s.path == path
+        };
+        if is_settings {
+            RELOAD_REQUESTED.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Returns and clears a pending reload request. See [`Settings::note_saved`].
+    pub fn take_reload_request() -> bool {
+        RELOAD_REQUESTED.swap(false, Ordering::Relaxed)
     }
 
     pub fn reload() -> apperr::Result<()> {

--- a/crates/edit/src/bin/edit/state.rs
+++ b/crates/edit/src/bin/edit/state.rs
@@ -153,6 +153,14 @@ pub struct State {
     pub file_picker_overwrite_warning: Option<PathBuf>,            // The path the warning is about.
     pub file_picker_autocomplete: Vec<DisplayablePathBuf>,
 
+    // Left-hand file browser pane (Yazi-like).
+    pub file_pane_visible: bool,
+    pub file_pane_focus: bool, // Request to move keyboard focus into the pane.
+    pub file_pane_dir: DisplayablePathBuf,
+    pub file_pane_dir_revision: u64, // Bumped every time `file_pane_dir` changes.
+    pub file_pane_entries: Option<[Vec<DisplayablePathBuf>; 3]>, // ["..", directories, files]
+    pub wants_editor_focus: bool,    // Request to move keyboard focus back into the editor.
+
     pub wants_search: StateSearch,
     pub search_needle: String,
     pub search_replacement: String,
@@ -203,6 +211,13 @@ impl State {
             file_picker_entries: None,
             file_picker_overwrite_warning: None,
             file_picker_autocomplete: Vec::new(),
+
+            file_pane_visible: false,
+            file_pane_focus: false,
+            file_pane_dir: Default::default(),
+            file_pane_dir_revision: 0,
+            file_pane_entries: None,
+            wants_editor_focus: false,
 
             wants_search: StateSearch { kind: StateSearchKind::Hidden, focus: false },
             search_needle: Default::default(),

--- a/crates/edit/src/bin/edit/state.rs
+++ b/crates/edit/src/bin/edit/state.rs
@@ -6,7 +6,7 @@ use std::ffi::{OsStr, OsString};
 use std::mem;
 use std::path::{Path, PathBuf};
 
-use edit::framebuffer::IndexedColor;
+use edit::framebuffer::{DEFAULT_THEME, INDEXED_COLORS_COUNT, IndexedColor};
 use edit::helpers::*;
 use edit::oklab::StraightRgba;
 use edit::tui::*;
@@ -134,6 +134,10 @@ pub struct State {
     pub menubar_color_bg: StraightRgba,
     pub menubar_color_fg: StraightRgba,
 
+    /// The terminal's own palette, as queried via OSC at startup. Used to
+    /// restore colors when the `theme` setting is switched back to `system`.
+    pub system_theme: [StraightRgba; INDEXED_COLORS_COUNT],
+
     pub documents: DocumentManager,
 
     // A ring buffer of the last 10 errors.
@@ -184,6 +188,7 @@ impl State {
         Ok(Self {
             menubar_color_bg: StraightRgba::zero(),
             menubar_color_fg: StraightRgba::zero(),
+            system_theme: DEFAULT_THEME,
 
             documents: Default::default(),
 

--- a/crates/edit/src/framebuffer.rs
+++ b/crates/edit/src/framebuffer.rs
@@ -87,6 +87,99 @@ pub const DEFAULT_THEME: [StraightRgba; INDEXED_COLORS_COUNT] = [
     StraightRgba::from_be(0xbebebeff), // Foreground
 ];
 
+/// Catppuccin Latte palette (light). Uses the official ANSI color mapping.
+/// See: <https://github.com/catppuccin/catppuccin>
+pub const CATPPUCCIN_LATTE: [StraightRgba; INDEXED_COLORS_COUNT] = [
+    StraightRgba::from_be(0xbcc0ccff), // Black         (surface1)
+    StraightRgba::from_be(0xd20f39ff), // Red
+    StraightRgba::from_be(0x40a02bff), // Green
+    StraightRgba::from_be(0xdf8e1dff), // Yellow
+    StraightRgba::from_be(0x1e66f5ff), // Blue
+    StraightRgba::from_be(0xea76cbff), // Magenta       (pink)
+    StraightRgba::from_be(0x179299ff), // Cyan          (teal)
+    StraightRgba::from_be(0x5c5f77ff), // White         (subtext1)
+    StraightRgba::from_be(0xacb0beff), // BrightBlack    (surface2)
+    StraightRgba::from_be(0xd20f39ff), // BrightRed
+    StraightRgba::from_be(0x40a02bff), // BrightGreen
+    StraightRgba::from_be(0xdf8e1dff), // BrightYellow
+    StraightRgba::from_be(0x1e66f5ff), // BrightBlue
+    StraightRgba::from_be(0xea76cbff), // BrightMagenta
+    StraightRgba::from_be(0x179299ff), // BrightCyan
+    StraightRgba::from_be(0x6c6f85ff), // BrightWhite    (subtext0)
+    // --------
+    StraightRgba::from_be(0xeff1f5ff), // Background     (base)
+    StraightRgba::from_be(0x4c4f69ff), // Foreground     (text)
+];
+
+/// Catppuccin Frappé palette. Uses the official ANSI color mapping.
+pub const CATPPUCCIN_FRAPPE: [StraightRgba; INDEXED_COLORS_COUNT] = [
+    StraightRgba::from_be(0x51576dff), // Black         (surface1)
+    StraightRgba::from_be(0xe78284ff), // Red
+    StraightRgba::from_be(0xa6d189ff), // Green
+    StraightRgba::from_be(0xe5c890ff), // Yellow
+    StraightRgba::from_be(0x8caaeeff), // Blue
+    StraightRgba::from_be(0xf4b8e4ff), // Magenta       (pink)
+    StraightRgba::from_be(0x81c8beff), // Cyan          (teal)
+    StraightRgba::from_be(0xb5bfe2ff), // White         (subtext1)
+    StraightRgba::from_be(0x626880ff), // BrightBlack    (surface2)
+    StraightRgba::from_be(0xe78284ff), // BrightRed
+    StraightRgba::from_be(0xa6d189ff), // BrightGreen
+    StraightRgba::from_be(0xe5c890ff), // BrightYellow
+    StraightRgba::from_be(0x8caaeeff), // BrightBlue
+    StraightRgba::from_be(0xf4b8e4ff), // BrightMagenta
+    StraightRgba::from_be(0x81c8beff), // BrightCyan
+    StraightRgba::from_be(0xa5adceff), // BrightWhite    (subtext0)
+    // --------
+    StraightRgba::from_be(0x303446ff), // Background     (base)
+    StraightRgba::from_be(0xc6d0f5ff), // Foreground     (text)
+];
+
+/// Catppuccin Macchiato palette. Uses the official ANSI color mapping.
+pub const CATPPUCCIN_MACCHIATO: [StraightRgba; INDEXED_COLORS_COUNT] = [
+    StraightRgba::from_be(0x494d64ff), // Black         (surface1)
+    StraightRgba::from_be(0xed8796ff), // Red
+    StraightRgba::from_be(0xa6da95ff), // Green
+    StraightRgba::from_be(0xeed49fff), // Yellow
+    StraightRgba::from_be(0x8aadf4ff), // Blue
+    StraightRgba::from_be(0xf5bde6ff), // Magenta       (pink)
+    StraightRgba::from_be(0x8bd5caff), // Cyan          (teal)
+    StraightRgba::from_be(0xb8c0e0ff), // White         (subtext1)
+    StraightRgba::from_be(0x5b6078ff), // BrightBlack    (surface2)
+    StraightRgba::from_be(0xed8796ff), // BrightRed
+    StraightRgba::from_be(0xa6da95ff), // BrightGreen
+    StraightRgba::from_be(0xeed49fff), // BrightYellow
+    StraightRgba::from_be(0x8aadf4ff), // BrightBlue
+    StraightRgba::from_be(0xf5bde6ff), // BrightMagenta
+    StraightRgba::from_be(0x8bd5caff), // BrightCyan
+    StraightRgba::from_be(0xa5adcbff), // BrightWhite    (subtext0)
+    // --------
+    StraightRgba::from_be(0x24273aff), // Background     (base)
+    StraightRgba::from_be(0xcad3f5ff), // Foreground     (text)
+];
+
+/// Catppuccin Mocha palette (dark). Uses the official ANSI color mapping.
+pub const CATPPUCCIN_MOCHA: [StraightRgba; INDEXED_COLORS_COUNT] = [
+    StraightRgba::from_be(0x45475aff), // Black         (surface1)
+    StraightRgba::from_be(0xf38ba8ff), // Red
+    StraightRgba::from_be(0xa6e3a1ff), // Green
+    StraightRgba::from_be(0xf9e2afff), // Yellow
+    StraightRgba::from_be(0x89b4faff), // Blue
+    StraightRgba::from_be(0xf5c2e7ff), // Magenta       (pink)
+    StraightRgba::from_be(0x94e2d5ff), // Cyan          (teal)
+    StraightRgba::from_be(0xbac2deff), // White         (subtext1)
+    StraightRgba::from_be(0x585b70ff), // BrightBlack    (surface2)
+    StraightRgba::from_be(0xf38ba8ff), // BrightRed
+    StraightRgba::from_be(0xa6e3a1ff), // BrightGreen
+    StraightRgba::from_be(0xf9e2afff), // BrightYellow
+    StraightRgba::from_be(0x89b4faff), // BrightBlue
+    StraightRgba::from_be(0xf5c2e7ff), // BrightMagenta
+    StraightRgba::from_be(0x94e2d5ff), // BrightCyan
+    StraightRgba::from_be(0xa6adc8ff), // BrightWhite    (subtext0)
+    // --------
+    StraightRgba::from_be(0x1e1e2eff), // Background     (base)
+    StraightRgba::from_be(0xcdd6f4ff), // Foreground     (text)
+];
+
 /// A shoddy framebuffer for terminal applications.
 ///
 /// The idea is that you create a [`Framebuffer`], draw a bunch of text and
@@ -162,6 +255,17 @@ impl Framebuffer {
         if lightness[0] > lightness[1] {
             self.auto_colors.swap(0, 1);
         }
+    }
+
+    /// Actively paints the default background/foreground of every cell with the
+    /// given colors, instead of letting the terminal's own defaults show through.
+    ///
+    /// [`set_indexed_colors`](Self::set_indexed_colors) resets these fills to
+    /// transparent, so call this afterwards. This is used by fixed themes (e.g.
+    /// Catppuccin), whose base color must not depend on the terminal's palette.
+    pub fn set_base_fill(&mut self, background: StraightRgba, foreground: StraightRgba) {
+        self.background_fill = background;
+        self.foreground_fill = foreground;
     }
 
     /// Begins a new frame with the given `size`.

--- a/crates/edit/src/input.rs
+++ b/crates/edit/src/input.rs
@@ -18,7 +18,7 @@ use crate::vt;
 /// Of course you could just translate on the ABI boundary, but my hope is that this
 /// design lets me realize some restrictions early on that I can't foresee yet.
 #[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct InputKey(u32);
 
 impl InputKey {
@@ -212,6 +212,9 @@ pub mod kbmod {
     pub const CTRL: InputKeyMod = InputKeyMod::new(0x01000000);
     pub const ALT: InputKeyMod = InputKeyMod::new(0x02000000);
     pub const SHIFT: InputKeyMod = InputKeyMod::new(0x04000000);
+    /// The "Super" modifier (Windows/Command key), reported by the
+    /// Kitty keyboard protocol when enabled and forwarded by the terminal.
+    pub const SUPER: InputKeyMod = InputKeyMod::new(0x08000000);
 
     pub const CTRL_ALT: InputKeyMod = InputKeyMod::new(0x03000000);
     pub const CTRL_SHIFT: InputKeyMod = InputKeyMod::new(0x05000000);
@@ -381,6 +384,11 @@ impl<'input> Iterator for Stream<'_, '_, 'input> {
                             }
                         }
                         'Z' => return Some(Input::Keyboard(kbmod::SHIFT | vk::TAB)),
+                        'u' => {
+                            if let Some(input) = Self::parse_kitty_key(csi) {
+                                return Some(input);
+                            }
+                        }
                         '~' => {
                             const LUT: [u8; 35] = [
                                 0,
@@ -538,7 +546,44 @@ impl<'input> Stream<'_, '_, 'input> {
         if (p1 & 0x04) != 0 {
             modifiers |= kbmod::CTRL;
         }
+        if (p1 & 0x08) != 0 {
+            modifiers |= kbmod::SUPER;
+        }
         modifiers
+    }
+
+    /// Decodes a Kitty keyboard protocol key event of the form
+    /// `CSI <unicode-codepoint> ; <modifiers> u`.
+    ///
+    /// This is only ever received when the Kitty keyboard protocol has been
+    /// enabled during terminal setup (see the `edit` binary's `setup_terminal`),
+    /// which is gated on the terminal advertising support. Under the flags we
+    /// request, a handful of special keys (Enter/Tab/Escape/Backspace) and all
+    /// modified keys arrive in this form, so we map them back onto the existing
+    /// `vk`/`kbmod` model.
+    fn parse_kitty_key(csi: &vt::Csi) -> Option<Input<'input>> {
+        let cp = csi.params[0] as u32;
+        let modifiers = Self::parse_modifiers(csi);
+
+        let key = match cp {
+            13 => vk::RETURN,
+            9 => vk::TAB,
+            27 => vk::ESCAPE,
+            127 => vk::BACK,
+            // a-z: fold to A-Z so it matches the `vk` letter constants.
+            0x61..=0x7a => InputKey::new(cp & !0x20),
+            // Other printable ASCII passes through as-is.
+            0x20..=0x7e => InputKey::new(cp),
+            _ => return None,
+        };
+
+        // Translate the macOS clipboard shortcuts Super+C/V/X onto the existing
+        // Ctrl+C/V/X handling so all downstream copy/cut/paste logic is reused.
+        if modifiers.contains(kbmod::SUPER) && matches!(cp, 0x63 | 0x76 | 0x78) {
+            return Some(Input::Keyboard(kbmod::CTRL | key));
+        }
+
+        Some(Input::Keyboard(key | modifiers))
     }
 
     fn parse_xterm_mouse(params: &[u16], final_byte: char) -> Option<Input<'input>> {
@@ -590,5 +635,61 @@ impl<'input> Stream<'_, '_, 'input> {
         mouse.modifiers |= if (btn & CTRL) != 0 { kbmod::CTRL } else { kbmod::NONE };
 
         Some(Input::Mouse(mouse))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feeds `input` through the VT tokenizer and input parser and returns the
+    /// single keyboard key it decodes to (panicking otherwise).
+    fn decode_key(input: &str) -> InputKey {
+        let mut vt_parser = vt::Parser::new();
+        let mut parser = Parser::new();
+        let vt_stream = vt_parser.parse(input);
+        let mut stream = parser.parse(vt_stream);
+        match stream.next() {
+            Some(Input::Keyboard(key)) => key,
+            _ => panic!("expected a keyboard input"),
+        }
+    }
+
+    #[test]
+    fn kitty_super_c_maps_to_ctrl_c() {
+        // CSI 99 ; 9 u -> Super+c (modifier 9 = base 1 + super bit 8).
+        assert_eq!(decode_key("\x1b[99;9u"), kbmod::CTRL | vk::C);
+    }
+
+    #[test]
+    fn kitty_super_v_and_x_map_to_ctrl() {
+        assert_eq!(decode_key("\x1b[118;9u"), kbmod::CTRL | vk::V);
+        assert_eq!(decode_key("\x1b[120;9u"), kbmod::CTRL | vk::X);
+    }
+
+    #[test]
+    fn kitty_ctrl_c_maps_to_ctrl_c() {
+        // CSI 99 ; 5 u -> Ctrl+c (modifier 5 = base 1 + ctrl bit 4).
+        assert_eq!(decode_key("\x1b[99;5u"), kbmod::CTRL | vk::C);
+    }
+
+    #[test]
+    fn kitty_plain_letter() {
+        // CSI 97 u -> plain 'a', folded to A with no modifiers.
+        assert_eq!(decode_key("\x1b[97u"), vk::A);
+    }
+
+    #[test]
+    fn kitty_super_plain_letter() {
+        // Super+a (non clipboard key) keeps the SUPER modifier.
+        assert_eq!(decode_key("\x1b[97;9u"), kbmod::SUPER | vk::A);
+    }
+
+    #[test]
+    fn kitty_special_keys() {
+        assert_eq!(decode_key("\x1b[13u"), vk::RETURN);
+        assert_eq!(decode_key("\x1b[9u"), vk::TAB);
+        assert_eq!(decode_key("\x1b[27u"), vk::ESCAPE);
+        assert_eq!(decode_key("\x1b[127u"), vk::BACK);
     }
 }

--- a/crates/edit/src/tui.rs
+++ b/crates/edit/src/tui.rs
@@ -435,6 +435,12 @@ impl Tui {
         self.framebuffer.set_indexed_colors(colors);
     }
 
+    /// Actively paints every cell's default background/foreground with the given
+    /// colors. See [`Framebuffer::set_base_fill()`].
+    pub fn set_base_fill(&mut self, background: StraightRgba, foreground: StraightRgba) {
+        self.framebuffer.set_base_fill(background, foreground);
+    }
+
     /// Set up translations for Ctrl/Alt/Shift modifiers.
     pub fn setup_modifier_translations(&mut self, translations: ModifierTranslations) {
         self.modifier_translations = translations;

--- a/crates/lsh/definitions/c.lsh
+++ b/crates/lsh/definitions/c.lsh
@@ -1,6 +1,5 @@
 #[display_name = "C"]
 #[path = "**/*.c"]
-#[path = "**/*.h"]
 pub fn c() {
     until /$/ {
         yield other;

--- a/crates/lsh/definitions/c.lsh
+++ b/crates/lsh/definitions/c.lsh
@@ -1,0 +1,53 @@
+#[display_name = "C"]
+#[path = "**/*.c"]
+#[path = "**/*.h"]
+pub fn c() {
+    until /$/ {
+        yield other;
+
+        if /\/\/.*/ {
+            yield comment;
+        } else if /\/\*/ {
+            loop {
+                yield comment;
+                await input;
+                if /\*\// {
+                    yield comment;
+                    break;
+                }
+            }
+        } else if /#\s*(?:include|define|undef|if|ifdef|ifndef|elif|else|endif|pragma|error|warning|line)\>/ {
+            // Preprocessor directive.
+            yield markup.link;
+        } else if /"/ {
+            until /$/ {
+                yield string;
+                if /\\./ {}
+                else if /"/ { yield string; break; }
+                await input;
+            }
+        } else if /'/ {
+            single_quote_string();
+        } else if /(?:break|case|continue|default|do|else|for|goto|if|return|switch|while)\>/ {
+            yield keyword.control;
+        } else if /(?:auto|const|enum|extern|inline|register|restrict|sizeof|static|struct|typedef|union|volatile|_Alignas|_Alignof|_Atomic|_Noreturn|_Static_assert|_Thread_local)\>/ {
+            yield keyword.other;
+        } else if /(?:void|char|short|int|long|float|double|signed|unsigned|_Bool|_Complex|_Imaginary|bool|size_t|ssize_t|ptrdiff_t|wchar_t|int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|intptr_t|uintptr_t|FILE|va_list)\>/ {
+            yield keyword.other;
+        } else if /(?:true|false|NULL)\>/ {
+            yield constant.language;
+        } else if /(?i:-?(?:0x[\da-f]+|0b[01]+|[\d']+\.?[\d']*|\.[\d]+)(?:e[+-]?[\d]+)?)[uUlLfF]*/ {
+            if /\w+/ {
+                // Invalid numeric literal
+            } else {
+                yield constant.numeric;
+            }
+        } else if /(\w+)\s*\(/ {
+            yield $1 as method;
+        } else if /\w+/ {
+            // Gobble word chars to align the next iteration on a word boundary.
+        }
+
+        yield other;
+    }
+}

--- a/crates/lsh/definitions/cpp.lsh
+++ b/crates/lsh/definitions/cpp.lsh
@@ -1,0 +1,66 @@
+#[display_name = "C++"]
+#[path = "**/*.cpp"]
+#[path = "**/*.cxx"]
+#[path = "**/*.cc"]
+#[path = "**/*.hpp"]
+#[path = "**/*.hxx"]
+#[path = "**/*.hh"]
+#[path = "**/*.ipp"]
+#[path = "**/*.tpp"]
+pub fn cpp() {
+    until /$/ {
+        yield other;
+
+        if /\/\/.*/ {
+            yield comment;
+        } else if /\/\*/ {
+            loop {
+                yield comment;
+                await input;
+                if /\*\// {
+                    yield comment;
+                    break;
+                }
+            }
+        } else if /#\s*(?:include|define|undef|if|ifdef|ifndef|elif|else|endif|pragma|error|warning|line|import|export)\>/ {
+            // Preprocessor directive.
+            yield markup.link;
+        } else if /R"[^(]*\(/ {
+            // Raw string literal. Escapes are not processed, may span lines.
+            loop {
+                yield string;
+                if /\)[^"]*"/ { yield string; break; }
+                await input;
+            }
+        } else if /"/ {
+            until /$/ {
+                yield string;
+                if /\\./ {}
+                else if /"/ { yield string; break; }
+                await input;
+            }
+        } else if /'/ {
+            single_quote_string();
+        } else if /(?:break|case|catch|continue|co_await|co_return|co_yield|default|do|else|for|goto|if|return|switch|throw|try|while)\>/ {
+            yield keyword.control;
+        } else if /(?:alignas|alignof|auto|class|concept|const|consteval|constexpr|constinit|const_cast|decltype|delete|dynamic_cast|enum|explicit|export|extern|friend|inline|mutable|namespace|new|noexcept|operator|override|private|protected|public|register|reinterpret_cast|requires|sizeof|static|static_assert|static_cast|struct|template|this|thread_local|typedef|typeid|typename|union|using|virtual|volatile)\>/ {
+            yield keyword.other;
+        } else if /(?:void|bool|char|char8_t|char16_t|char32_t|wchar_t|short|int|long|float|double|signed|unsigned|size_t|ssize_t|ptrdiff_t|int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|string|wstring|string_view|vector|map|set|unordered_map|unordered_set|pair|tuple|array|shared_ptr|unique_ptr|weak_ptr|optional|variant)\>/ {
+            yield keyword.other;
+        } else if /(?:true|false|nullptr|NULL)\>/ {
+            yield constant.language;
+        } else if /(?i:-?(?:0x[\da-f']+|0b[01']+|[\d']+\.?[\d']*|\.[\d]+)(?:e[+-]?[\d]+)?)[uUlLfFzZ]*/ {
+            if /\w+/ {
+                // Invalid numeric literal
+            } else {
+                yield constant.numeric;
+            }
+        } else if /(\w+)\s*(?:<[^;{}()]*>)?\s*\(/ {
+            yield $1 as method;
+        } else if /\w+/ {
+            // Gobble word chars to align the next iteration on a word boundary.
+        }
+
+        yield other;
+    }
+}

--- a/crates/lsh/definitions/cpp.lsh
+++ b/crates/lsh/definitions/cpp.lsh
@@ -2,6 +2,7 @@
 #[path = "**/*.cpp"]
 #[path = "**/*.cxx"]
 #[path = "**/*.cc"]
+#[path = "**/*.h"]
 #[path = "**/*.hpp"]
 #[path = "**/*.hxx"]
 #[path = "**/*.hh"]

--- a/crates/lsh/definitions/css.lsh
+++ b/crates/lsh/definitions/css.lsh
@@ -1,0 +1,51 @@
+#[display_name = "CSS"]
+#[path = "**/*.css"]
+#[path = "**/*.scss"]
+#[path = "**/*.less"]
+pub fn css() {
+    until /$/ {
+        yield other;
+
+        if /\/\/.*/ {
+            // Line comment (SCSS/LESS).
+            yield comment;
+        } else if /\/\*/ {
+            loop {
+                yield comment;
+                await input;
+                if /\*\// {
+                    yield comment;
+                    break;
+                }
+            }
+        } else if /'/ {
+            single_quote_string();
+        } else if /"/ {
+            double_quote_string();
+        } else if /@[\w-]+/ {
+            // At-rule such as @media, @import, @keyframes.
+            yield keyword.control;
+        } else if /\$[\w-]+/ {
+            // SCSS variable.
+            yield variable;
+        } else if /!important\>/ {
+            yield keyword.other;
+        } else if /#[\da-fA-F]{3,8}\>/ {
+            // Hex color.
+            yield constant.numeric;
+        } else if /(?i:-?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?)(?:px|em|rem|ex|ch|vw|vh|vmin|vmax|cm|mm|in|pt|pc|deg|rad|grad|turn|ms|s|fr|%)?/ {
+            yield constant.numeric;
+        } else if /([\w-]+)\s*:/ {
+            // Property name.
+            yield $1 as variable;
+            yield other;
+        } else if /[.#][\w-]+/ {
+            // Class or id selector.
+            yield keyword.other;
+        } else if /\w+/ {
+            // Element selector / value keyword. Gobble to a word boundary.
+        }
+
+        yield other;
+    }
+}

--- a/crates/lsh/definitions/go.lsh
+++ b/crates/lsh/definitions/go.lsh
@@ -1,0 +1,56 @@
+#[display_name = "Go"]
+#[path = "**/*.go"]
+pub fn go() {
+    until /$/ {
+        yield other;
+
+        if /\/\/.*/ {
+            yield comment;
+        } else if /\/\*/ {
+            loop {
+                yield comment;
+                await input;
+                if /\*\// {
+                    yield comment;
+                    break;
+                }
+            }
+        } else if /`/ {
+            // Raw string literal. Escapes are not processed, may span lines.
+            loop {
+                yield string;
+                if /`/ { yield string; break; }
+                await input;
+            }
+        } else if /"/ {
+            until /$/ {
+                yield string;
+                if /\\./ {}
+                else if /"/ { yield string; break; }
+                await input;
+            }
+        } else if /'(?:\\.|[^'\\])'/ {
+            yield string;
+        } else if /(?:break|case|continue|default|else|fallthrough|for|goto|if|range|return|select|switch)\>/ {
+            yield keyword.control;
+        } else if /(?:chan|const|defer|func|go|import|interface|map|package|struct|type|var)\>/ {
+            yield keyword.other;
+        } else if /(?:bool|byte|complex64|complex128|error|float32|float64|int|int8|int16|int32|int64|rune|string|uint|uint8|uint16|uint32|uint64|uintptr|any)\>/ {
+            yield keyword.other;
+        } else if /(?:true|false|nil|iota)\>/ {
+            yield constant.language;
+        } else if /(?i:-?(?:0x[\da-f_]+|0b[01_]+|0o[0-7_]+|[\d_]+\.?[\d_]*|\.[\d_]+)(?:e[+-]?[\d_]+)?)i?/ {
+            if /\w+/ {
+                // Invalid numeric literal
+            } else {
+                yield constant.numeric;
+            }
+        } else if /(\w+)\s*\(/ {
+            yield $1 as method;
+        } else if /\w+/ {
+            // Gobble word chars to align the next iteration on a word boundary.
+        }
+
+        yield other;
+    }
+}

--- a/crates/lsh/definitions/html.lsh
+++ b/crates/lsh/definitions/html.lsh
@@ -1,0 +1,94 @@
+#[display_name = "HTML"]
+#[path = "**/*.html"]
+#[path = "**/*.htm"]
+#[path = "**/*.xhtml"]
+#[path = "**/*.vue"]
+#[path = "**/*.svelte"]
+pub fn html() {
+    until /$/ {
+        yield other;
+
+        if /<!--/ {
+            loop {
+                yield comment;
+                await input;
+                if /-->/ {
+                    yield comment;
+                    break;
+                }
+            }
+        } else if /<!(DOCTYPE|doctype)[^>]*>/ {
+            yield $1 as constant.language;
+            yield other;
+        } else if /<(?:script)\>/ {
+            // Embedded JavaScript.
+            yield constant.language;
+            yield other;
+            html_tag_attributes();
+            loop {
+                await input;
+                if /\s*<\/script\s*>/ {
+                    yield constant.language;
+                    yield other;
+                    break;
+                } else {
+                    javascript();
+                    if /.*/ {}
+                }
+            }
+        } else if /<(?:style)\>/ {
+            // Embedded CSS.
+            yield constant.language;
+            yield other;
+            html_tag_attributes();
+            loop {
+                await input;
+                if /\s*<\/style\s*>/ {
+                    yield constant.language;
+                    yield other;
+                    break;
+                } else {
+                    css();
+                    if /.*/ {}
+                }
+            }
+        } else if /<([\w:.-]+)/ {
+            yield $1 as constant.language;
+            yield other;
+            html_tag_attributes();
+        } else if /<\/([\w:.-]+)\s*>/ {
+            yield $1 as constant.language;
+            yield other;
+        } else if /(?:&#|&)[\w:.-]+;/ {
+            yield constant.numeric;
+        }
+
+        yield other;
+    }
+}
+
+// Consumes tag attributes up to and including the closing `>`.
+fn html_tag_attributes() {
+    until />/ {
+        yield other;
+        await input;
+
+        if /([\w:.-]+)\s*=/ {
+            yield $1 as variable;
+            yield other;
+        } else if /"/ {
+            until /"/ {
+                yield string;
+                await input;
+            }
+            yield string;
+        } else if /'/ {
+            until /'/ {
+                yield string;
+                await input;
+            }
+            yield string;
+        }
+    }
+    yield other;
+}

--- a/crates/lsh/definitions/rust.lsh
+++ b/crates/lsh/definitions/rust.lsh
@@ -1,0 +1,65 @@
+#[display_name = "Rust"]
+#[path = "**/*.rs"]
+pub fn rust() {
+    until /$/ {
+        yield other;
+
+        if /\/\/.*/ {
+            yield comment;
+        } else if /\/\*/ {
+            loop {
+                yield comment;
+                await input;
+                if /\*\// {
+                    yield comment;
+                    break;
+                }
+            }
+        } else if /r#*"/ {
+            // Raw string literal. Escapes are not processed.
+            loop {
+                yield string;
+                if /"#*/ { yield string; break; }
+                await input;
+            }
+        } else if /b?"/ {
+            until /$/ {
+                yield string;
+                if /\\./ {}
+                else if /"/ { yield string; break; }
+                await input;
+            }
+        } else if /b?'(?:\\.|[^'\\])'/ {
+            yield string;
+        } else if /'(?:static|_|[a-zA-Z]\w*)\>/ {
+            // Lifetime annotation.
+            yield variable;
+        } else if /#!?\[/ {
+            // Attribute.
+            yield markup.link;
+        } else if /(?:as|break|continue|else|for|if|in|loop|match|return|while)\>/ {
+            yield keyword.control;
+        } else if /(?:async|await|const|crate|dyn|enum|extern|fn|impl|let|mod|move|mut|pub|ref|self|Self|static|struct|super|trait|type|union|unsafe|use|where)\>/ {
+            yield keyword.other;
+        } else if /(?:bool|char|str|u8|u16|u32|u64|u128|usize|i8|i16|i32|i64|i128|isize|f32|f64|String|Vec|Option|Result|Box|Rc|Arc|Cell|RefCell)\>/ {
+            yield keyword.other;
+        } else if /(?:true|false|None|Some|Ok|Err)\>/ {
+            yield constant.language;
+        } else if /(?i:-?(?:0x[\da-f_]+|0b[01_]+|0o[0-7_]+|[\d_]+\.?[\d_]*|\.[\d_]+)(?:e[+-]?[\d_]+)?)(?:u8|u16|u32|u64|u128|usize|i8|i16|i32|i64|i128|isize|f32|f64)?/ {
+            if /\w+/ {
+                // Invalid numeric literal
+            } else {
+                yield constant.numeric;
+            }
+        } else if /(\w+)!/ {
+            // Macro invocation.
+            yield $1 as method;
+        } else if /(\w+)\s*\(/ {
+            yield $1 as method;
+        } else if /\w+/ {
+            // Gobble word chars to align the next iteration on a word boundary.
+        }
+
+        yield other;
+    }
+}

--- a/crates/lsh/definitions/toml.lsh
+++ b/crates/lsh/definitions/toml.lsh
@@ -1,0 +1,54 @@
+#[display_name = "TOML"]
+#[path = "**/*.toml"]
+#[path = "**/Cargo.lock"]
+pub fn toml() {
+    // Table headers such as [package] or [[bin]].
+    if /\s*\[\[?[^\]]*\]\]?/ {
+        yield meta.header;
+        yield other;
+    }
+
+    until /$/ {
+        yield other;
+
+        if /#.*/ {
+            yield comment;
+        } else if /([\w.-]+|"[^"]*"|'[^']*')\s*=/ {
+            yield $1 as variable;
+            yield other;
+        } else if /'''/ {
+            // Multi-line literal string.
+            loop {
+                yield string;
+                if /'''/ { yield string; break; }
+                await input;
+            }
+        } else if /"""/ {
+            // Multi-line basic string.
+            loop {
+                yield string;
+                if /"""/ { yield string; break; }
+                await input;
+            }
+        } else if /'/ {
+            single_quote_string();
+        } else if /"/ {
+            double_quote_string();
+        } else if /(?:true|false)\>/ {
+            yield constant.language;
+        } else if /\d{4}-\d{2}-\d{2}(?:[Tt ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?)?/ {
+            // Date / time.
+            yield constant.numeric;
+        } else if /(?i:[+-]?(?:0x[\da-f_]+|0b[01_]+|0o[0-7_]+|inf|nan|[\d_]+\.?[\d_]*|\.[\d_]+)(?:e[+-]?[\d_]+)?)/ {
+            if /\w+/ {
+                // Not a number after all.
+            } else {
+                yield constant.numeric;
+            }
+        } else if /\w+/ {
+            // Gobble word chars to align the next iteration on a word boundary.
+        }
+
+        yield other;
+    }
+}

--- a/crates/lsh/definitions/typescript.lsh
+++ b/crates/lsh/definitions/typescript.lsh
@@ -1,0 +1,67 @@
+#[display_name = "TypeScript"]
+#[path = "**/*.ts"]
+#[path = "**/*.tsx"]
+#[path = "**/*.mts"]
+#[path = "**/*.cts"]
+pub fn typescript() {
+    until /$/ {
+        yield other;
+
+        if /\/\/.*/ {
+            yield comment;
+        } else if /\/\*/ {
+            loop {
+                yield comment;
+                await input;
+                if /\*\// {
+                    yield comment;
+                    break;
+                }
+            }
+        } else if /'/ {
+            until /$/ {
+                yield string;
+                if /\\./ {}
+                else if /'/ { yield string; break; }
+                await input;
+            }
+        } else if /"/ {
+            until /$/ {
+                yield string;
+                if /\\./ {}
+                else if /"/ { yield string; break; }
+                await input;
+            }
+        } else if /`/ {
+            loop {
+                yield string;
+                if /\\./ {}
+                else if /`/ { yield string; break; }
+                await input;
+            }
+        } else if /@\w+/ {
+            // Decorator.
+            yield markup.link;
+        } else if /(?:break|case|catch|continue|debugger|default|do|else|finally|for|if|return|switch|throw|try|while)\>/ {
+            yield keyword.control;
+        } else if /(?:abstract|as|asserts|async|await|class|const|declare|delete|enum|export|extends|function|implements|import|in|infer|instanceof|interface|is|keyof|let|namespace|new|of|override|private|protected|public|readonly|satisfies|static|super|this|type|typeof|var|void|yield)\>/ {
+            yield keyword.other;
+        } else if /(?:any|boolean|never|number|object|string|symbol|undefined|unknown|bigint|Array|Promise|Record|Partial|Readonly|Map|Set)\>/ {
+            yield keyword.other;
+        } else if /(?:true|false|null|undefined|NaN|Infinity)\>/ {
+            yield constant.language;
+        } else if /(?i:-?(?:0x[\da-f_]+|0b[01_]+|0o[0-7_]+|[\d_]+\.?[\d_]*|\.[\d_]+)(?:e[+-]?[\d_]+)?)n?/ {
+            if /\w+/ {
+                // Invalid numeric literal
+            } else {
+                yield constant.numeric;
+            }
+        } else if /(\w+)\s*\(/ {
+            yield $1 as method;
+        } else if /\w+/ {
+            // Gobble word chars to align the next iteration on a word boundary.
+        }
+
+        yield other;
+    }
+}

--- a/crates/lsh/definitions/xml.lsh
+++ b/crates/lsh/definitions/xml.lsh
@@ -1,7 +1,6 @@
 #[display_name = "XML"]
 #[path = "**/*.csproj.user"]
 #[path = "**/*.csproj"]
-#[path = "**/*.html"]
 #[path = "**/*.nuspec"]
 #[path = "**/*.proj"]
 #[path = "**/*.props"]

--- a/i18n/edit.toml
+++ b/i18n/edit.toml
@@ -909,6 +909,9 @@ vi = "Đặt tiêu điểm vào thanh trạng thái"
 zh-hans = "聚焦状态栏"
 zh-hant = "聚焦狀態列"
 
+[ViewFilePane]
+en = "File Browser"
+
 [ViewWordWrap]
 en = "Word Wrap"
 ar = "التفاف النص"


### PR DESCRIPTION
## Summary

Adds high-quality `.lsh` syntax-highlighting grammars for eight more languages: **Rust, Go, C, C++, TypeScript/TSX, TOML, HTML, and CSS**.

Each grammar covers, where the language has them:
- Line and block comments
- String literals with escapes, plus raw/multiline forms (Rust `r#"…"#`/`b"…"`, Go/C++ raw strings, TypeScript template literals, C/C++ char literals, TOML `"""`/`'''`)
- Numeric literals (hex/bin/oct/float/exponent, digit separators, type suffixes)
- Control-flow keywords vs. other keywords
- Builtin/primitive types (folded into `keyword.other`, since the highlight-kind set has no dedicated type kind)
- Language constants (`true`/`false`/`nil`/`nullptr`/`None`/…)
- Attributes/decorators/preprocessor directives (`markup.link`)

### Highlights
- **HTML** embeds the **CSS** and **JavaScript** grammars inside `<style>` and `<script>` blocks (delegation pattern borrowed from `markdown.lsh`). The `.html` association was moved off the XML grammar onto the new HTML grammar.
- **C/C++** share the same structure; C++ adds templates, `constexpr`/`co_*`, raw strings, scoped enums, and the STL type vocabulary.
- **TypeScript** is based on the JavaScript grammar with TS-only keywords (`interface`, `type`, `readonly`, `satisfies`, …), builtin types, and decorators.

### Associations
Wired automatically from each grammar's `#[path]` globs (the build script generates `FILE_ASSOCIATIONS`):
`.rs`→Rust, `.go`→Go, `.c/.h`→C, `.cpp/.cxx/.cc/.hpp/.hxx/.hh/.ipp/.tpp`→C++, `.ts/.tsx/.mts/.cts`→TypeScript, `.toml`/`Cargo.lock`→TOML, `.html/.htm/.xhtml/.vue/.svelte`→HTML, `.css/.scss/.less`→CSS.

### Testing
- Added representative sample files under `assets/highlighting-tests/` for each new language, exercising every construct.
- Drove the real `Highlighter` over every sample and confirmed each produces a rich, correct span distribution (comments, strings, numbers, keywords, types, methods) with no runaway loops.
- `cargo build --release`, `cargo test -p lsh`, and `cargo test -p edit` all pass.

### Note on the `.lsh` format
Two engine constraints shaped the grammars:
1. Unbounded repetition (`*`/`+`) is not supported on complex alternation groups — number suffixes use plain charsets (`[uUlLfF]*`) and char literals reuse the string helper.
2. An optional **alternation** prefix before a top-level delimiter branch (e.g. `(?:u8|u|U|L)?"`) breaks the fast-skip interesting-charset collection and causes whole lines to be skipped. Simplified C/C++ string/char literals to plain `"`/`'` delimiters (a single optional char like Rust's `b?"` is fine, but an alternation group is not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)