### PR TITLE
input: Translate \0 as Ctrl+Space

### DIFF
--- a/crates/edit/src/input.rs
+++ b/crates/edit/src/input.rs
@@ -340,6 +340,7 @@ impl<'input> Iterator for Stream<'_, '_, 'input> {
                         let key = ch as u32 | 0x40;
                         return Some(Input::Keyboard(kbmod::CTRL | InputKey::new(key)));
                     }
+                    ' ' => return Some(Input::Keyboard(kbmod::CTRL | vk::SPACE)),
                     '\x7f' => return Some(Input::Keyboard(vk::BACK)),
                     _ => {}
                 },

--- a/crates/edit/src/input.rs
+++ b/crates/edit/src/input.rs
@@ -333,14 +333,18 @@ impl<'input> Iterator for Stream<'_, '_, 'input> {
                     return Some(Input::Text(text));
                 }
                 vt::Token::Ctrl(ch) => match ch {
-                    '\0' | '\t' | '\r' => return Some(Input::Keyboard(InputKey::new(ch as u32))),
+                    '\0' => {
+                        // Both Ctrl+Space and Ctrl+Shift+2 produce \0, and
+                        // Ctrl+Space is probably the more common of the two.
+                        return Some(Input::Keyboard(kbmod::CTRL | vk::SPACE));
+                    }
+                    '\t' | '\r' => return Some(Input::Keyboard(InputKey::new(ch as u32))),
                     '\n' => return Some(Input::Keyboard(kbmod::CTRL | vk::RETURN)),
                     ..='\x1a' => {
                         // Shift control code to A-Z
                         let key = ch as u32 | 0x40;
                         return Some(Input::Keyboard(kbmod::CTRL | InputKey::new(key)));
                     }
-                    ' ' => return Some(Input::Keyboard(kbmod::CTRL | vk::SPACE)),
                     '\x7f' => return Some(Input::Keyboard(vk::BACK)),
                     _ => {}
                 },

--- a/crates/edit/src/sys/windows.rs
+++ b/crates/edit/src/sys/windows.rs
@@ -335,7 +335,8 @@ pub fn read_stdin(arena: &Arena, mut timeout: time::Duration) -> Option<BString<
                 Console::KEY_EVENT => {
                     let event = unsafe { &inp.Event.KeyEvent };
                     let ch = unsafe { event.uChar.UnicodeChar };
-                    if event.bKeyDown != 0 && ch != 0 {
+                    let sc = event.wVirtualScanCode;
+                    if event.bKeyDown != 0 && (ch != 0 || sc == 0) {
                         utf16_buf[utf16_buf_len] = MaybeUninit::new(ch);
                         utf16_buf_len += 1;
                     }

--- a/crates/edit/src/vt.rs
+++ b/crates/edit/src/vt.rs
@@ -172,7 +172,12 @@ impl<'input> Stream<'_, 'input> {
                         self.parser.state = State::Esc;
                         self.off += 1;
                     }
-                    c @ (0x00..0x20 | 0x7f) => {
+                    0x00 => {
+                        // Ctrl+Space and Ctrl+Shift+2 both produce ^@, or \0.
+                        self.off += 1;
+                        return Some(Token::Ctrl(' '));
+                    }
+                    c @ (0x01..0x20 | 0x7f) => {
                         self.off += 1;
                         return Some(Token::Ctrl(c as char));
                     }

--- a/crates/edit/src/vt.rs
+++ b/crates/edit/src/vt.rs
@@ -172,12 +172,7 @@ impl<'input> Stream<'_, 'input> {
                         self.parser.state = State::Esc;
                         self.off += 1;
                     }
-                    0x00 => {
-                        // Ctrl+Space and Ctrl+Shift+2 both produce ^@, or \0.
-                        self.off += 1;
-                        return Some(Token::Ctrl(' '));
-                    }
-                    c @ (0x01..0x20 | 0x7f) => {
+                    c @ (0x00..0x20 | 0x7f) => {
                         self.off += 1;
                         return Some(Token::Ctrl(c as char));
                     }


### PR DESCRIPTION
There exists an ambiguous control character in standard 7-bit ASCII terminals, `\0`, which is the traditional encoding for Ctrl+Space and Ctrl+Shift+2 (or Ctrl+@ on US-104 keyboards).

```
Space 0x20 0b00100000
    @ 0x40 0b01000000
                ^^^^^
		control character bits 0b00000
```

Anyway, edit didn't support it. We also had a bug in the Windows KEY_EVENT parser where we would disregard otherwise acceptable inputs such as `\0` without a scancode (indicating that it was generated by the console subsystem directly).

Supersedes #870