### PR TITLE
ci: Check clippy on workspace packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
       - name: Run tests
         run: cargo test --all-features --all-targets
       - name: Run clippy
-        run: cargo clippy --all-features --all-targets -- --no-deps --deny warnings
+        run: cargo clippy --workspace --all-features --all-targets -- --no-deps --deny warnings

--- a/crates/stdext/src/arena/scratch.rs
+++ b/crates/stdext/src/arena/scratch.rs
@@ -134,6 +134,7 @@ mod multi_threaded {
     static INIT_SIZE: AtomicUsize = AtomicUsize::new(128 * MEBI);
 
     /// Sets the default scratch arena size.
+    #[allow(dead_code)]
     pub fn init(capacity: usize) -> io::Result<()> {
         if capacity != 0 {
             INIT_SIZE.store(capacity, Ordering::Relaxed);


### PR DESCRIPTION
Ensure clippy runs cleanly on all packages in the workspace:

```console
$ cargo clippy --workspace --all-features --all-targets
warning: function `init` is never used
   --> crates/stdext/src/arena/scratch.rs:137:12
    |
137 |     pub fn init(capacity: usize) -> io::Result<()> {
    |            ^^^^
    |
    = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

```

