### PR TITLE
Add support for Ruby string interpolation highlighting

### DIFF
--- a/assets/highlighting-tests/ruby.rb
+++ b/assets/highlighting-tests/ruby.rb
@@ -39,7 +39,9 @@ MAX_SIZE = 10
 'single quotes with escape: \' \n \t \\'
 "double quotes with escape: \" \n \t \\"
 "interpolated: #{1 + 1} and a # that is not a comment"
+"escaped \#{1 + 1} is not interpolated"
 `echo shell command`
+`echo #{Time.now}`
 
 # Symbols and variables
 :symbol

--- a/crates/lsh/definitions/ruby.lsh
+++ b/crates/lsh/definitions/ruby.lsh
@@ -27,11 +27,25 @@ pub fn ruby() {
         } else if /'/ {
             single_quote_string();
         } else if /"/ {
-            double_quote_string();
+            until /$/ {
+                yield string;
+                if /\\./ {
+                    // Escape sequences. `\#{` escapes interpolation, so this must come first.
+                } else if /#\{[^}]*\}/ {
+                    // Interpolation. Nested braces, as in `#{ {a: 1} }`, are not supported.
+                    yield variable;
+                } else if /"/ {
+                    yield string;
+                    break;
+                }
+            }
         } else if /`/ {
             until /$/ {
+                yield string;
                 if /\\./ {
                     // Escape sequences
+                } else if /#\{[^}]*\}/ {
+                    yield variable;
                 } else if /`/ {
                     yield string;
                     break;

--- a/crates/lsh/definitions/ruby.lsh
+++ b/crates/lsh/definitions/ruby.lsh
@@ -39,11 +39,8 @@ pub fn ruby() {
             }
         } else if /(?:begin|break|case|do|elsif|else|end|ensure|for|if|in|next|redo|rescue|retry|return|then|unless|until|when|while)\>/ {
             yield keyword.control;
-        } else if /def\s+\w+\.(\w+[!?=]?)/ {
-            // Singleton method, as in `def self.foo`.
-            yield keyword.other;
-            yield $1 as method;
-        } else if /def\s+(\w+[!?=]?)/ {
+        } else if /def\s+(?:\w+\.)?(\w+[!?=]?)/ {
+            // The optional prefix covers singleton methods, as in `def self.foo`.
             yield keyword.other;
             yield $1 as method;
         } else if /(?:BEGIN|END|__ENCODING__|__FILE__|__LINE__|alias|and|class|defined\?|def|module|not|or|self|super|undef|yield)\>/ {

--- a/crates/lsh/definitions/ruby.lsh
+++ b/crates/lsh/definitions/ruby.lsh
@@ -47,7 +47,7 @@ pub fn ruby() {
             yield keyword.other;
         } else if /(?:true|false|nil)\>/ {
             yield constant.language;
-        } else if /(?i:-?(?:0x[\da-f_]+|0b[01_]+|0o[0-7_]+|[\d_]+\.[\d_]+(?:e[+-]?[\d_]+)?|[\d_]+(?:e[+-]?[\d_]+)?)r?i?)/ {
+        } else if /(?i:-?(?:0x[\da-f_]+|0b[01_]+|0o[0-7_]+|[\d_]+(?:\.[\d_]+)?(?:e[+-]?[\d_]+)?)r?i?)/ {
             // Floats need digits on both sides of the dot, so that `1..2` and
             // `1.upto(2)` don't swallow the dot.
             if /\w+/ {


### PR DESCRIPTION
Follow-up to #849.

This pull request improves the Ruby syntax highlighting logic and its corresponding test cases. The main focus is on better handling of string interpolation and escape sequences, as well as simplifying and correcting method definition parsing.

### String and interpolation handling

* Enhanced parsing of double-quoted (`"..."`) and backtick (`` `...` ``) strings to properly distinguish between escape sequences, interpolations (e.g., `#{...}`), and regular string content. Escaped interpolations (e.g., `\#{...}`) are now correctly recognized as plain strings, not variables.
* Added new test cases in `ruby.rb` to verify correct handling of escaped interpolations and interpolations in backtick strings.

**Before:**

<img width="488" height="108" alt="image" src="https://github.com/user-attachments/assets/32fec1d5-5369-48b6-bffb-97311a9455b2" />

**After:**

<img width="489" height="145" alt="image" src="https://github.com/user-attachments/assets/759cd3af-4a85-4cbf-abbf-4d2bf6e5454c" />


### Method definition parsing

* Simplified the regular expression for parsing method definitions to handle both regular and singleton methods (e.g., `def foo` and `def self.foo`) in a single pattern, reducing code duplication.

### Number literal parsing

* Corrected the regular expression for number literals to ensure floats and integers are parsed accurately, preventing issues with constructs like `1..2` and `1.upto(2)`.