### PR TITLE
Distinguish the menu and status bars

### DIFF
--- a/crates/edit/src/bin/edit/draw_menubar.rs
+++ b/crates/edit/src/bin/edit/draw_menubar.rs
@@ -3,6 +3,7 @@
 
 use edit::helpers::*;
 use edit::input::{kbmod, vk};
+use edit::oklab::StraightRgba;
 use edit::tui::*;
 use stdext::arena_format;
 
@@ -12,8 +13,10 @@ use crate::state::*;
 
 pub fn draw_menubar(ctx: &mut Context, state: &mut State) {
     ctx.menubar_begin();
-    ctx.attr_background_rgba(state.menubar_color_bg);
-    ctx.attr_foreground_rgba(state.menubar_color_fg);
+    // EN: Keep the menu row visually distinct with a white background and black text.
+    // 中文：選單列固定使用白色背景與黑色文字，使其與編輯區清楚區隔。
+    ctx.attr_background_rgba(StraightRgba::from_rgba(0xffffffff));
+    ctx.attr_foreground_rgba(StraightRgba::from_rgba(0x000000ff));
     {
         let contains_focus = ctx.contains_focus();
 

--- a/crates/edit/src/bin/edit/draw_statusbar.rs
+++ b/crates/edit/src/bin/edit/draw_statusbar.rs
@@ -7,6 +7,7 @@ use edit::helpers::*;
 use edit::icu;
 use edit::input::vk;
 use edit::lsh::LANGUAGES;
+use edit::oklab::StraightRgba;
 use edit::tui::*;
 use stdext::arena::scratch_arena;
 use stdext::arena_format;
@@ -18,8 +19,10 @@ use crate::state::*;
 pub fn draw_statusbar(ctx: &mut Context, state: &mut State) {
     ctx.table_begin("statusbar");
     ctx.attr_focus_well();
-    ctx.attr_background_rgba(state.menubar_color_bg);
-    ctx.attr_foreground_rgba(state.menubar_color_fg);
+    // EN: Use a green status row with white text for a consistent high-contrast footer.
+    // 中文：狀態列固定使用綠色背景與白色文字，形成一致且高對比的頁尾。
+    ctx.attr_background_rgba(StraightRgba::from_rgba(0x008000ff));
+    ctx.attr_foreground_rgba(StraightRgba::from_rgba(0xffffffff));
     ctx.table_set_cell_gap(Size { width: 2, height: 0 });
     ctx.attr_intrinsic_size(Size { width: COORD_TYPE_SAFE_MAX, height: 1 });
     ctx.attr_padding(Rect::two(0, 1));


### PR DESCRIPTION
## Summary
- render the menu row with a white background and black text
- render the status row with a green background and white text
- keep the change limited to the two bar renderers

## Validation
- `cargo test --all-features --all-targets` on Windows and WSL/Ubuntu
- `cargo clippy --workspace --all-features --all-targets -- --no-deps --deny warnings` on Windows and WSL/Ubuntu

## Contribution ownership
This contribution is entirely my own work. It is not created on behalf of, or connected with, any organization or company. I agree to contribute it under the repository's MIT License and to the repository's applicable contribution terms.