### PR TITLE
Use fixed-width ASCII checkbox markers

### DIFF
--- a/crates/edit/src/tui.rs
+++ b/crates/edit/src/tui.rs
@@ -2074,17 +2074,18 @@ impl<'a> Context<'a, '_> {
         self.button_activated()
     }
 
-    /// Creates a checkbox with the given text.
-    /// Returns true if the checkbox was activated.
+    /// EN: Creates a checkbox with fixed-width ASCII markers that render consistently in terminals.
+    /// 中文：使用固定寬度的 ASCII 標記建立核取方塊，確保各終端機一致顯示。
+    /// EN: Returns true if the checkbox was activated.
+    /// 中文：核取方塊被啟用時回傳 true。
     pub fn checkbox(&mut self, classname: &'static str, text: &str, checked: &mut bool) -> bool {
         self.styled_label_begin(classname);
         self.attr_focusable();
         if self.is_focused() {
             self.attr_reverse();
         }
-        self.styled_label_add_text(if *checked { "[◼ " } else { "[◻ " });
+        self.styled_label_add_text(if *checked { "[x] " } else { "[ ] " });
         self.styled_label_add_text(text);
-        self.styled_label_add_text("]");
         self.styled_label_end();
 
         let activated = self.button_activated();


### PR DESCRIPTION
## Summary
- replace terminal-dependent checkbox glyphs with fixed-width `[ ]` and `[x]` markers
- avoid box-border displacement caused by ambiguous glyph widths in some terminals
- keep the change limited to the generic checkbox renderer

## Validation
- `cargo test --all-features --all-targets` on Windows and WSL/Ubuntu
- `cargo clippy --workspace --all-features --all-targets -- --no-deps --deny warnings` on Windows and WSL/Ubuntu

## Contribution ownership
This contribution is entirely my own work. It is not created on behalf of, or connected with, any organization or company. I agree to contribute it under the repository's MIT License and to the repository's applicable contribution terms.