### PR TITLE
enhancement: add missing common file extensions to language detection

### DIFF
--- a/crates/lsh/definitions/cpp.lsh
+++ b/crates/lsh/definitions/cpp.lsh
@@ -4,6 +4,9 @@
 #[path = "**/*.cxx"]
 #[path = "**/*.hpp"]
 #[path = "**/*.h"]
+#[path = "**/*.hh"]
+#[path = "**/*.hxx"]
+#[path = "**/*.ixx"]
 pub fn cpp() {
     until /$/ {
         yield other;

--- a/crates/lsh/definitions/fsharp.lsh
+++ b/crates/lsh/definitions/fsharp.lsh
@@ -2,6 +2,7 @@
 #[path = "**/*.fs"]
 #[path = "**/*.fsi"]
 #[path = "**/*.fsx"]
+#[path = "**/*.fsscript"]
 pub fn fsharp() {
     // Compiler and script directives always occupy the entire line.
     if /\s*#(?:if|else|endif|light|line|load|nowarn|time|help|quit|r|I)\>.*/ {

--- a/crates/lsh/definitions/json.lsh
+++ b/crates/lsh/definitions/json.lsh
@@ -1,6 +1,8 @@
 #[display_name = "JSON"]
 #[path = "**/*.json"]
 #[path = "**/*.jsonc"]
+#[path = "**/*.jsonl"]
+#[path = "**/*.ndjson"]
 pub fn json() {
     until /$/ {
         yield other;

--- a/crates/lsh/definitions/markdown.lsh
+++ b/crates/lsh/definitions/markdown.lsh
@@ -1,5 +1,6 @@
 #[display_name = "Markdown"]
 #[path = "**/*.md"]
+#[path = "**/*.markdown"]
 pub fn markdown() {
     // Any lines that start with a tab or 4+ spaces are code blocks.
     if /(?:\t|    ).*/ {

--- a/crates/lsh/definitions/xml.lsh
+++ b/crates/lsh/definitions/xml.lsh
@@ -13,7 +13,7 @@
 #[path = "**/*.vcxproj"]
 #[path = "**/*.xaml"]
 #[path = "**/*.xml"]
-#[path = "**/*.xml"]
+#[path = "**/*.xhtml"]
 pub fn xml() {
     until /$/ {
         yield other;


### PR DESCRIPTION
This adds support for several commonly used file extensions that are currently missing from the existing LSH language definitions.

### Scope

The changes are limited to existing language definitions and do not introduce any new dependencies or syntax highlighting logic.

The changes include:

* C++: add `.hh`, `.hxx`, and `.ixx`
* F#: add `.fsscript`
* JSON: add `.jsonl` and `.ndjson`
* Markdown: add `.markdown`
* XML: add `.xhtml`
* remove the duplicate `.xml` path from the XML definition

### Validation

* `cargo test -q`

These changes only expand file extension detection for existing language definitions and should not affect the highlighting behavior of existing file types.

### Notes

- fixes: #944